### PR TITLE
use the correct index for globalGetters/globallSetters arrays

### DIFF
--- a/WebAssembly/Compile.cs
+++ b/WebAssembly/Compile.cs
@@ -566,8 +566,8 @@ namespace WebAssembly
 											throw new ModuleLoadException($"Exported global index of {index} is greater than the number of globals {globalGetters.Length}.", preIndexOffset);
 
 										{
-											var getter = globalGetters[i];
-											var setter = globalSetters[i];
+											var getter = globalGetters[index];
+											var setter = globalSetters[index];
 											var property = exportsBuilder.DefineProperty(name, PropertyAttributes.None, getter.Type.ToSystemType(), System.Type.EmptyTypes);
 											var wrappedGet = exportsBuilder.DefineMethod("get_" + name,
 												exportedPropertyAttributes,

--- a/WebAssembly/Compile.cs
+++ b/WebAssembly/Compile.cs
@@ -563,7 +563,7 @@ namespace WebAssembly
 										break;
 									case ExternalKind.Global:
 										if (index >= globalGetters.Length)
-											throw new ModuleLoadException($"Exported global index of {index} is greater than the number of globals {globalGetters.Length}.", preIndexOffset);
+											throw new ModuleLoadException($"Exported global index of {index} is greater than or equal to the number of globals {globalGetters.Length}.", preIndexOffset);
 
 										{
 											var getter = globalGetters[index];


### PR DESCRIPTION
I'm very new to this codebase and attempted to compile some wasm from a binary and ran into an index out of range exception.

For these two lines of code I think you meant to use 'index' to index into the array instead of 'i'. Just before these two lines you do a check to make sure that 'index' is less than the length of globalGetters array.