### PR TITLE
Fixes #18 Not zero initializing new memory, causing grow memory test failures

### DIFF
--- a/WebAssembly.Tests/Runtime/SpecTests.cs
+++ b/WebAssembly.Tests/Runtime/SpecTests.cs
@@ -697,7 +697,6 @@ namespace WebAssembly.Runtime
                 58, // Not equal: 2 and -1
                 59, // Not equal: 4 and -1
                 60, // Not equal: 10 and 0,
-                97, // Not equal: 0 and 215,
                 101, // StackSizeIncorrectException
             };
 


### PR DESCRIPTION
Removes emptyPage member.

Adds CopyBlock, InitBlock functions.

Note: CopyBlock is not used.

Replaces zeroing Marshal.Copy with call to InitBlock.

Zeroes newly memory on alloc and realloc.