### PR TITLE
Implement sign-extension operators

### DIFF
--- a/WebAssembly.Tests/Instructions/Int32Extend16SignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int32Extend16SignedTests.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int32Extend16Signed"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int32Extend16SignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int32Extend16Signed"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int32Extend16Signed_Compiled()
+        {
+            var exports = ConversionTestBase<int, int>.CreateInstance(
+                new LocalGet(0),
+                new Int32Extend16Signed(),
+                new End());
+
+            //Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/i32.wast
+            Assert.AreEqual(0, exports.Test(0));
+            Assert.AreEqual(32767, exports.Test(0x7fff));
+            Assert.AreEqual(-32768, exports.Test(0x8000));
+            Assert.AreEqual(-1, exports.Test(0xffff));
+            Assert.AreEqual(0, exports.Test(0x01230000));
+            Assert.AreEqual(-0x8000, exports.Test(unchecked((int)0xfedc8000)));
+            Assert.AreEqual(-1, exports.Test(-1));
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int32Extend8SignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int32Extend8SignedTests.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int32Extend8Signed"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int32Extend8SignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int32Extend8Signed"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int32Extend8Signed_Compiled()
+        {
+            var exports = ConversionTestBase<int, int>.CreateInstance(
+                new LocalGet(0),
+                new Int32Extend8Signed(),
+                new End());
+
+            //Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/i32.wast
+            Assert.AreEqual(0, exports.Test(0));
+            Assert.AreEqual(127, exports.Test(0x7f));
+            Assert.AreEqual(-128, exports.Test(0x80));
+            Assert.AreEqual(-1, exports.Test(0xff));
+            Assert.AreEqual(0, exports.Test(0x01234500));
+            Assert.AreEqual(-0x80, exports.Test(unchecked((int)0xfedcba80)));
+            Assert.AreEqual(-1, exports.Test(-1));
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int64Extend16SignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int64Extend16SignedTests.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int64Extend16Signed"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int64Extend16SignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int64Extend16Signed"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int64Extend16Signed_Compiled()
+        {
+            var exports = ConversionTestBase<long, long>.CreateInstance(
+                new LocalGet(0),
+                new Int64Extend16Signed(),
+                new End());
+
+            //Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/i64.wast
+            Assert.AreEqual(0, exports.Test(0));
+            Assert.AreEqual(32767, exports.Test(0x7fff));
+            Assert.AreEqual(-32768, exports.Test(0x8000));
+            Assert.AreEqual(-1, exports.Test(0xffff));
+            Assert.AreEqual(0, exports.Test(0x0123456789abc0000));
+            Assert.AreEqual(-0x8000, exports.Test(unchecked((long)0xfedcba9876548000)));
+            Assert.AreEqual(-1, exports.Test(-1));
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int64Extend32SignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int64Extend32SignedTests.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int64Extend32Signed"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int64Extend32SignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int64Extend32Signed"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int64Extend32Signed_Compiled()
+        {
+            var exports = ConversionTestBase<long, long>.CreateInstance(
+                new LocalGet(0),
+                new Int64Extend32Signed(),
+                new End());
+
+            //Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/i64.wast
+            Assert.AreEqual(0, exports.Test(0));
+            Assert.AreEqual(32767, exports.Test(0x7fff));
+            Assert.AreEqual(32768, exports.Test(0x8000));
+            Assert.AreEqual(65535, exports.Test(0xffff));
+            Assert.AreEqual(0x7fffffff, exports.Test(0x7fffffff));
+            Assert.AreEqual(-0x80000000, exports.Test(0x80000000));
+            Assert.AreEqual(-1, exports.Test(0xffffffff));
+            Assert.AreEqual(0, exports.Test(0x0123456700000000));
+            Assert.AreEqual(-0x80000000, exports.Test(unchecked((long)0xfedcba9880000000)));
+            Assert.AreEqual(-1, exports.Test(-1));
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int64Extend8SignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int64Extend8SignedTests.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int64Extend8Signed"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int64Extend8SignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int64Extend8Signed"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int64Extend8Signed_Compiled()
+        {
+            var exports = ConversionTestBase<long, long>.CreateInstance(
+                new LocalGet(0),
+                new Int64Extend8Signed(),
+                new End());
+
+            //Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/i64.wast
+            Assert.AreEqual(0, exports.Test(0));
+            Assert.AreEqual(127, exports.Test(0x7f));
+            Assert.AreEqual(-128, exports.Test(0x80));
+            Assert.AreEqual(-1, exports.Test(0xff));
+            Assert.AreEqual(0, exports.Test(0x0123456789abcd00));
+            Assert.AreEqual(-0x80, exports.Test(unchecked((long)0xfedcba9876543280)));
+            Assert.AreEqual(-1, exports.Test(-1));
+        }
+    }
+}

--- a/WebAssembly/Instruction.cs
+++ b/WebAssembly/Instruction.cs
@@ -293,6 +293,11 @@ namespace WebAssembly
                     case OpCode.Int64ReinterpretFloat64: yield return new Int64ReinterpretFloat64(); break;
                     case OpCode.Float32ReinterpretInt32: yield return new Float32ReinterpretInt32(); break;
                     case OpCode.Float64ReinterpretInt64: yield return new Float64ReinterpretInt64(); break;
+                    case OpCode.Int32Extend8Signed: yield return new Int32Extend8Signed(); break;
+                    case OpCode.Int32Extend16Signed: yield return new Int32Extend16Signed(); break;
+                    case OpCode.Int64Extend8Signed: yield return new Int64Extend8Signed(); break;
+                    case OpCode.Int64Extend16Signed: yield return new Int64Extend16Signed(); break;
+                    case OpCode.Int64Extend32Signed: yield return new Int64Extend32Signed(); break;
                 }
             }
         }

--- a/WebAssembly/Instructions/Int32Extend16Signed.cs
+++ b/WebAssembly/Instructions/Int32Extend16Signed.cs
@@ -1,0 +1,41 @@
+using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Extend a signed 16-bit integer to a 32-bit integer.
+    /// </summary>
+    public class Int32Extend16Signed : SimpleInstruction
+    {
+        /// <summary>
+        /// Always <see cref="OpCode.Int32Extend16Signed"/>.
+        /// </summary>
+        public sealed override OpCode OpCode => OpCode.Int32Extend16Signed;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int32Extend16Signed"/> instance.
+        /// </summary>
+        public Int32Extend16Signed()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count < 1)
+                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
+
+            var type = stack.Pop();
+
+            if (type != WebAssemblyValueType.Int32)
+                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int32, type);
+
+            context.Emit(OpCodes.Conv_I2);
+            context.Emit(OpCodes.Conv_I4);
+
+            stack.Push(WebAssemblyValueType.Int32);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int32Extend8Signed.cs
+++ b/WebAssembly/Instructions/Int32Extend8Signed.cs
@@ -1,0 +1,41 @@
+using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Extend a signed 8-bit integer to a 32-bit integer.
+    /// </summary>
+    public class Int32Extend8Signed : SimpleInstruction
+    {
+        /// <summary>
+        /// Always <see cref="OpCode.Int32Extend8Signed"/>.
+        /// </summary>
+        public sealed override OpCode OpCode => OpCode.Int32Extend8Signed;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int32Extend8Signed"/> instance.
+        /// </summary>
+        public Int32Extend8Signed()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count < 1)
+                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
+
+            var type = stack.Pop();
+
+            if (type != WebAssemblyValueType.Int32)
+                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int32, type);
+
+            context.Emit(OpCodes.Conv_I1);
+            context.Emit(OpCodes.Conv_I4);
+
+            stack.Push(WebAssemblyValueType.Int32);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int64Extend16Signed.cs
+++ b/WebAssembly/Instructions/Int64Extend16Signed.cs
@@ -1,0 +1,41 @@
+using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Extend a signed 16-bit integer to a 64-bit integer.
+    /// </summary>
+    public class Int64Extend16Signed : SimpleInstruction
+    {
+        /// <summary>
+        /// Always <see cref="OpCode.Int64Extend16Signed"/>.
+        /// </summary>
+        public sealed override OpCode OpCode => OpCode.Int64Extend16Signed;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int64Extend16Signed"/> instance.
+        /// </summary>
+        public Int64Extend16Signed()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count < 1)
+                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
+
+            var type = stack.Pop();
+
+            if (type != WebAssemblyValueType.Int64)
+                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int64, type);
+
+            context.Emit(OpCodes.Conv_I2);
+            context.Emit(OpCodes.Conv_I8);
+
+            stack.Push(WebAssemblyValueType.Int64);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int64Extend32Signed.cs
+++ b/WebAssembly/Instructions/Int64Extend32Signed.cs
@@ -1,0 +1,41 @@
+using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Extend a signed 32-bit integer to a 64-bit integer.
+    /// </summary>
+    public class Int64Extend32Signed : SimpleInstruction
+    {
+        /// <summary>
+        /// Always <see cref="OpCode.Int64Extend32Signed"/>.
+        /// </summary>
+        public sealed override OpCode OpCode => OpCode.Int64Extend32Signed;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int64Extend32Signed"/> instance.
+        /// </summary>
+        public Int64Extend32Signed()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count < 1)
+                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
+
+            var type = stack.Pop();
+
+            if (type != WebAssemblyValueType.Int64)
+                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int64, type);
+
+            context.Emit(OpCodes.Conv_I4);
+            context.Emit(OpCodes.Conv_I8);
+
+            stack.Push(WebAssemblyValueType.Int64);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int64Extend8Signed.cs
+++ b/WebAssembly/Instructions/Int64Extend8Signed.cs
@@ -1,0 +1,41 @@
+using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Extend a signed 8-bit integer to a 64-bit integer.
+    /// </summary>
+    public class Int64Extend8Signed : SimpleInstruction
+    {
+        /// <summary>
+        /// Always <see cref="OpCode.Int64Extend8Signed"/>.
+        /// </summary>
+        public sealed override OpCode OpCode => OpCode.Int64Extend8Signed;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int64Extend8Signed"/> instance.
+        /// </summary>
+        public Int64Extend8Signed()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count < 1)
+                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
+
+            var type = stack.Pop();
+
+            if (type != WebAssemblyValueType.Int64)
+                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int64, type);
+
+            context.Emit(OpCodes.Conv_I1);
+            context.Emit(OpCodes.Conv_I8);
+
+            stack.Push(WebAssemblyValueType.Int64);
+        }
+    }
+}

--- a/WebAssembly/OpCode.cs
+++ b/WebAssembly/OpCode.cs
@@ -1041,6 +1041,36 @@ namespace WebAssembly
         /// </summary>
         [OpCodeCharacteristics("f64.reinterpret_i64")]
         Float64ReinterpretInt64 = 0xbf,
+
+        /// <summary>
+        /// Extend a signed 8-bit integer to a 32-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i32.extend8_s")]
+        Int32Extend8Signed = 0xc0,
+
+        /// <summary>
+        /// Extend a signed 16-bit integer to a 32-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i32.extend16_s")]
+        Int32Extend16Signed = 0xc1,
+
+        /// <summary>
+        /// Extend a signed 8-bit integer to a 64-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i64.extend8_s")]
+        Int64Extend8Signed = 0xc2,
+
+        /// <summary>
+        /// Extend a signed 16-bit integer to a 64-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i64.extend16_s")]
+        Int64Extend16Signed = 0xc3,
+
+        /// <summary>
+        /// Extend a signed 32-bit integer to a 64-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i64.extend32_s")]
+        Int64Extend32Signed = 0xc4,
     }
 
     static class OpCodeExtensions


### PR DESCRIPTION
This PR implements the sign-extension operators that have been added to WebAssembly.

As noted [here](https://github.com/WebAssembly/proposals/blob/master/finished-proposals.md), the [sign-extension operators proposal](https://github.com/WebAssembly/spec/blob/master/proposals/sign-extension-ops/Overview.md) is a "finished proposal" - it has reached phase 4, and it is included in the latest draft of the specification.

And as noted [here](https://webassembly.org/roadmap/), sign-extension operators are already supported in Chrome, Firefox, Wasmtime, Wasmer, and Node.js (but not Safari).