### PR TITLE
Implement saturating truncation instructions

### DIFF
--- a/WebAssembly.Tests/Instructions/InstructionTests.cs
+++ b/WebAssembly.Tests/Instructions/InstructionTests.cs
@@ -37,6 +37,7 @@ namespace WebAssembly.Instructions
         {
             var mismatch = string.Join(", ",
                 InstructionTypes
+                .Where(x => !x.IsSubclassOf(typeof(MiscellaneousInstruction)))
                 .Select(type => (
                 OpCode: ((Instruction)type.GetConstructor(System.Type.EmptyTypes).Invoke(null)).OpCode.ToString(),
                 TypeName: type.Name
@@ -46,6 +47,26 @@ namespace WebAssembly.Instructions
                 );
 
             Assert.AreEqual("", mismatch, "Instructions whose name do not match their opcode found.");
+        }
+
+        /// <summary>
+        /// Ensures that miscellaneous instruction names match their miscellaneous opcode name.
+        /// </summary>
+        [TestMethod]
+        public void Instruction_NameMatchesMiscellaneousOpcode()
+        {
+            var mismatch = string.Join(", ",
+                InstructionTypes
+                    .Where(x => x.IsSubclassOf(typeof(MiscellaneousInstruction)))
+                    .Select(type => (
+                        MiscellaneousOpCode: ((MiscellaneousInstruction)type.GetConstructor(System.Type.EmptyTypes).Invoke(null)).MiscellaneousOpCode.ToString(),
+                        TypeName: type.Name
+                    ))
+                    .Where(result => result.MiscellaneousOpCode != result.TypeName)
+                    .Select(result => result.TypeName)
+            );
+
+            Assert.AreEqual("", mismatch, "Instructions whose name do not match their miscellaneous opcode found.");
         }
 
         /// <summary>

--- a/WebAssembly.Tests/Instructions/Int32TruncateSaturateFloat32SignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int32TruncateSaturateFloat32SignedTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int32TruncateSaturateFloat32Signed"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int32TruncateSaturateFloat32SignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int32TruncateSaturateFloat32Signed"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int32TruncateSaturatedSignedFloat32_Compiled()
+        {
+            var exports = ConversionTestBase<float, int>.CreateInstance(
+                new LocalGet(0),
+                new Int32TruncateSaturateFloat32Signed(),
+                new End());
+
+            // Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/conversions.wast
+            Assert.AreEqual(0, exports.Test(0.0f));
+            Assert.AreEqual(0, exports.Test(-0.0f));
+            Assert.AreEqual(0, exports.Test(float.Epsilon));
+            Assert.AreEqual(0, exports.Test(-float.Epsilon));
+            Assert.AreEqual(1, exports.Test(1.0f));
+            Assert.AreEqual(1, exports.Test(BitConverter.Int32BitsToSingle(0x3f8ccccd)));
+            Assert.AreEqual(1, exports.Test(1.5f));
+            Assert.AreEqual(-1, exports.Test(-1.0f));
+            Assert.AreEqual(-1, exports.Test(BitConverter.Int32BitsToSingle(unchecked((int)0xbf8ccccd))));
+            Assert.AreEqual(-1, exports.Test(-1.5f));
+            Assert.AreEqual(-1, exports.Test(-1.9f));
+            Assert.AreEqual(-2, exports.Test(-2.0f));
+            Assert.AreEqual(2147483520, exports.Test(2147483520.0f));
+            Assert.AreEqual(-2147483648, exports.Test(-2147483648.0f));
+            Assert.AreEqual(0x7fffffff, exports.Test(2147483648.0f));
+            Assert.AreEqual(unchecked((int)0x80000000), exports.Test(-2147483904.0f));
+            Assert.AreEqual(0x7fffffff, exports.Test(float.PositiveInfinity));
+            Assert.AreEqual(unchecked((int)0x80000000), exports.Test(float.NegativeInfinity));
+            Assert.AreEqual(0, exports.Test(float.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(float.NaN, 0x200000)));
+            Assert.AreEqual(0, exports.Test(-float.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(-float.NaN, 0x200000)));
+        }
+
+        private static float AddPayload(float floatValue, int payload)
+        {
+            var floatValueAsInt = BitConverter.SingleToInt32Bits(floatValue);
+            floatValueAsInt |= payload;
+            return BitConverter.Int32BitsToSingle(floatValueAsInt);
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int32TruncateSaturateFloat32UnsignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int32TruncateSaturateFloat32UnsignedTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int32TruncateSaturateFloat32Unsigned"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int32TruncateSaturateFloat32UnsignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int32TruncateSaturateFloat32Unsigned"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int32TruncateSaturatedUnsignedFloat32_Compiled()
+        {
+            var exports = ConversionTestBase<float, int>.CreateInstance(
+                new LocalGet(0),
+                new Int32TruncateSaturateFloat32Unsigned(),
+                new End());
+
+            // Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/conversions.wast
+            Assert.AreEqual(0, exports.Test(0.0f));
+            Assert.AreEqual(0, exports.Test(-0.0f));
+            Assert.AreEqual(0, exports.Test(float.Epsilon));
+            Assert.AreEqual(0, exports.Test(-float.Epsilon));
+            Assert.AreEqual(1, exports.Test(1.0f));
+            Assert.AreEqual(1, exports.Test(BitConverter.Int32BitsToSingle(0x3f8ccccd)));
+            Assert.AreEqual(1, exports.Test(1.5f));
+            Assert.AreEqual(1, exports.Test(1.9f));
+            Assert.AreEqual(2, exports.Test(2.0f));
+            Assert.AreEqual(-2147483648, exports.Test(2147483648f));
+            Assert.AreEqual(-256, exports.Test(4294967040.0f));
+            Assert.AreEqual(0, exports.Test(BitConverter.Int32BitsToSingle(unchecked((int)0xbf666666))));
+            Assert.AreEqual(0, exports.Test(BitConverter.Int32BitsToSingle(unchecked((int)0xbf7fffff))));
+            Assert.AreEqual(unchecked((int)0xffffffff), exports.Test(4294967296.0f));
+            Assert.AreEqual(0x00000000, exports.Test(-1.0f));
+            Assert.AreEqual(unchecked((int)0xffffffff), exports.Test(float.PositiveInfinity));
+            Assert.AreEqual(0x00000000, exports.Test(float.NegativeInfinity));
+            Assert.AreEqual(0, exports.Test(float.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(float.NaN, 0x200000)));
+            Assert.AreEqual(0, exports.Test(-float.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(-float.NaN, 0x200000)));
+        }
+
+        private static float AddPayload(float floatValue, int payload)
+        {
+            var floatValueAsInt = BitConverter.SingleToInt32Bits(floatValue);
+            floatValueAsInt |= payload;
+            return BitConverter.Int32BitsToSingle(floatValueAsInt);
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int32TruncateSaturateFloat64SignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int32TruncateSaturateFloat64SignedTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int32TruncateSaturateFloat64Signed"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int32TruncateSaturateFloat64SignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int32TruncateSaturateFloat64Signed"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int32TruncateSaturatedSignedFloat64_Compiled()
+        {
+            var exports = ConversionTestBase<double, int>.CreateInstance(
+                new LocalGet(0),
+                new Int32TruncateSaturateFloat64Signed(),
+                new End());
+
+            // Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/conversions.wast
+            Assert.AreEqual(0, exports.Test(0.0));
+            Assert.AreEqual(0, exports.Test(-0.0));
+            Assert.AreEqual(0, exports.Test(double.Epsilon));
+            Assert.AreEqual(0, exports.Test(-double.Epsilon));
+            Assert.AreEqual(1, exports.Test(1.0));
+            Assert.AreEqual(1, exports.Test(BitConverter.Int64BitsToDouble(0x3ff199999999999a)));
+            Assert.AreEqual(1, exports.Test(1.5));
+            Assert.AreEqual(-1, exports.Test(-1.0));
+            Assert.AreEqual(-1, exports.Test(BitConverter.Int64BitsToDouble(unchecked((long)0xbff199999999999a))));
+            Assert.AreEqual(-1, exports.Test(-1.5));
+            Assert.AreEqual(-1, exports.Test(-1.9));
+            Assert.AreEqual(-2, exports.Test(-2.0));
+            Assert.AreEqual(2147483647, exports.Test(2147483647.0));
+            Assert.AreEqual(-2147483648, exports.Test(-2147483648.0));
+            Assert.AreEqual(0x7fffffff, exports.Test(2147483648.0));
+            Assert.AreEqual(unchecked((int)0x80000000), exports.Test(-2147483649.0));
+            Assert.AreEqual(0x7fffffff, exports.Test(double.PositiveInfinity));
+            Assert.AreEqual(unchecked((int)0x80000000), exports.Test(double.NegativeInfinity));
+            Assert.AreEqual(0, exports.Test(double.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(double.NaN, 0x4000000000000)));
+            Assert.AreEqual(0, exports.Test(-double.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(-double.NaN, 0x4000000000000)));
+        }
+
+        private static double AddPayload(double doubleValue, long payload)
+        {
+            var doubleValueAsInt = BitConverter.DoubleToInt64Bits(doubleValue);
+            doubleValueAsInt |= payload;
+            return BitConverter.Int64BitsToDouble(doubleValueAsInt);
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int32TruncateSaturateFloat64UnsignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int32TruncateSaturateFloat64UnsignedTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int32TruncateSaturateFloat64Unsigned"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int32TruncateSaturateFloat64UnsignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int32TruncateSaturateFloat64Unsigned"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int32TruncateSaturatedUnsignedFloat64_Compiled()
+        {
+            var exports = ConversionTestBase<double, int>.CreateInstance(
+                new LocalGet(0),
+                new Int32TruncateSaturateFloat64Unsigned(),
+                new End());
+
+            // Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/conversions.wast
+            Assert.AreEqual(0, exports.Test(0.0));
+            Assert.AreEqual(0, exports.Test(-0.0));
+            Assert.AreEqual(0, exports.Test(double.Epsilon));
+            Assert.AreEqual(0, exports.Test(-double.Epsilon));
+            Assert.AreEqual(1, exports.Test(1.0));
+            Assert.AreEqual(1, exports.Test(BitConverter.Int64BitsToDouble(0x3ff199999999999a)));
+            Assert.AreEqual(1, exports.Test(1.5));
+            Assert.AreEqual(1, exports.Test(1.9));
+            Assert.AreEqual(2, exports.Test(2.0));
+            Assert.AreEqual(-2147483648, exports.Test(2147483648));
+            Assert.AreEqual(-1, exports.Test(4294967295.0));
+            Assert.AreEqual(0, exports.Test(BitConverter.Int64BitsToDouble(unchecked((long)0xbfeccccccccccccd))));
+            Assert.AreEqual(0, exports.Test(BitConverter.Int64BitsToDouble(unchecked((long)0xbfefffffffffffff))));
+            Assert.AreEqual(100000000, exports.Test(1e8));
+            Assert.AreEqual(unchecked((int)0xffffffff), exports.Test(4294967296.0));
+            Assert.AreEqual(0x00000000, exports.Test(-1.0));
+            Assert.AreEqual(unchecked((int)0xffffffff), exports.Test(1e16));
+            Assert.AreEqual(unchecked((int)0xffffffff), exports.Test(1e30));
+            Assert.AreEqual(unchecked((int)0xffffffff), exports.Test(9223372036854775808.0));
+            Assert.AreEqual(unchecked((int)0xffffffff), exports.Test(double.PositiveInfinity));
+            Assert.AreEqual(0x00000000, exports.Test(double.NegativeInfinity));
+            Assert.AreEqual(0, exports.Test(double.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(double.NaN, 0x4000000000000)));
+            Assert.AreEqual(0, exports.Test(-double.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(-double.NaN, 0x4000000000000)));
+        }
+
+        private static double AddPayload(double doubleValue, long payload)
+        {
+            var doubleValueAsInt = BitConverter.DoubleToInt64Bits(doubleValue);
+            doubleValueAsInt |= payload;
+            return BitConverter.Int64BitsToDouble(doubleValueAsInt);
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int64TruncateSaturateFloat32SignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int64TruncateSaturateFloat32SignedTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int64TruncateSaturateFloat32Signed"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int64TruncateSaturateFloat32SignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int64TruncateSaturateFloat32Signed"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int64TruncateSaturatedSignedFloat32_Compiled()
+        {
+            var exports = ConversionTestBase<float, long>.CreateInstance(
+                new LocalGet(0),
+                new Int64TruncateSaturateFloat32Signed(),
+                new End());
+
+            // Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/conversions.wast
+            Assert.AreEqual(0, exports.Test(0.0f));
+            Assert.AreEqual(0, exports.Test(-0.0f));
+            Assert.AreEqual(0, exports.Test(float.Epsilon));
+            Assert.AreEqual(0, exports.Test(-float.Epsilon));
+            Assert.AreEqual(1, exports.Test(1.0f));
+            Assert.AreEqual(1, exports.Test(BitConverter.Int32BitsToSingle(0x3f8ccccd)));
+            Assert.AreEqual(1, exports.Test(1.5f));
+            Assert.AreEqual(-1, exports.Test(-1.0f));
+            Assert.AreEqual(-1, exports.Test(BitConverter.Int32BitsToSingle(unchecked((int)0xbf8ccccd))));
+            Assert.AreEqual(-1, exports.Test(-1.5f));
+            Assert.AreEqual(-1, exports.Test(-1.9f));
+            Assert.AreEqual(-2, exports.Test(-2.0f));
+            Assert.AreEqual(4294967296, exports.Test(4294967296f));
+            Assert.AreEqual(-4294967296, exports.Test(-4294967296f));
+            Assert.AreEqual(9223371487098961920, exports.Test(9223371487098961920.0f));
+            Assert.AreEqual(-9223372036854775808, exports.Test(-9223372036854775808.0f));
+            Assert.AreEqual(0x7fffffffffffffff, exports.Test(9223372036854775808.0f));
+            Assert.AreEqual(unchecked((long)0x8000000000000000), exports.Test(-9223373136366403584.0f));
+            Assert.AreEqual(0x7fffffffffffffff, exports.Test(float.PositiveInfinity));
+            Assert.AreEqual(unchecked((long)0x8000000000000000), exports.Test(float.NegativeInfinity));
+            Assert.AreEqual(0, exports.Test(float.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(float.NaN, 0x200000)));
+            Assert.AreEqual(0, exports.Test(-float.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(-float.NaN, 0x200000)));
+        }
+
+        private static float AddPayload(float floatValue, int payload)
+        {
+            var floatValueAsInt = BitConverter.SingleToInt32Bits(floatValue);
+            floatValueAsInt |= payload;
+            return BitConverter.Int32BitsToSingle(floatValueAsInt);
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int64TruncateSaturateFloat32UnsignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int64TruncateSaturateFloat32UnsignedTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int64TruncateSaturateFloat32Unsigned"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int64TruncateSaturateFloat32UnsignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int64TruncateSaturateFloat32Unsigned"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int64TruncateSaturatedUnsignedFloat32_Compiled()
+        {
+            var exports = ConversionTestBase<float, long>.CreateInstance(
+                new LocalGet(0),
+                new Int64TruncateSaturateFloat32Unsigned(),
+                new End());
+
+            // Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/conversions.wast
+            Assert.AreEqual(0, exports.Test(0.0f));
+            Assert.AreEqual(0, exports.Test(-0.0f));
+            Assert.AreEqual(0, exports.Test(float.Epsilon));
+            Assert.AreEqual(0, exports.Test(-float.Epsilon));
+            Assert.AreEqual(1, exports.Test(1.0f));
+            Assert.AreEqual(1, exports.Test(BitConverter.Int32BitsToSingle(0x3f8ccccd)));
+            Assert.AreEqual(1, exports.Test(1.5f));
+            Assert.AreEqual(4294967296, exports.Test(4294967296f));
+            Assert.AreEqual(-1099511627776, exports.Test(18446742974197923840.0f));
+            Assert.AreEqual(0, exports.Test(BitConverter.Int32BitsToSingle(unchecked((int)0xbf666666))));
+            Assert.AreEqual(0, exports.Test(BitConverter.Int32BitsToSingle(unchecked((int)0xbf7fffff))));
+            Assert.AreEqual(unchecked((long)0xffffffffffffffff), exports.Test(18446744073709551616.0f));
+            Assert.AreEqual(0x0000000000000000, exports.Test(-1.0f));
+            Assert.AreEqual(unchecked((long)0xffffffffffffffff), exports.Test(float.PositiveInfinity));
+            Assert.AreEqual(0x0000000000000000, exports.Test(float.NegativeInfinity));
+            Assert.AreEqual(0, exports.Test(float.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(float.NaN, 0x200000)));
+            Assert.AreEqual(0, exports.Test(-float.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(-float.NaN, 0x200000)));
+        }
+
+        private static float AddPayload(float floatValue, int payload)
+        {
+            var floatValueAsInt = BitConverter.SingleToInt32Bits(floatValue);
+            floatValueAsInt |= payload;
+            return BitConverter.Int32BitsToSingle(floatValueAsInt);
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int64TruncateSaturateFloat64SignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int64TruncateSaturateFloat64SignedTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int64TruncateSaturateFloat64Signed"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int64TruncateSaturateFloat64SignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int64TruncateSaturateFloat64Signed"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int64TruncateSaturatedSignedFloat64_Compiled()
+        {
+            var exports = ConversionTestBase<double, long>.CreateInstance(
+                new LocalGet(0),
+                new Int64TruncateSaturateFloat64Signed(),
+                new End());
+
+            // Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/conversions.wast
+            Assert.AreEqual(0, exports.Test(0.0));
+            Assert.AreEqual(0, exports.Test(-0.0));
+            Assert.AreEqual(0, exports.Test(double.Epsilon));
+            Assert.AreEqual(0, exports.Test(-double.Epsilon));
+            Assert.AreEqual(1, exports.Test(1.0));
+            Assert.AreEqual(1, exports.Test(BitConverter.Int64BitsToDouble(0x3ff199999999999a)));
+            Assert.AreEqual(1, exports.Test(1.5));
+            Assert.AreEqual(-1, exports.Test(-1.0));
+            Assert.AreEqual(-1, exports.Test(BitConverter.Int64BitsToDouble(unchecked((long)0xbff199999999999a))));
+            Assert.AreEqual(-1, exports.Test(-1.5));
+            Assert.AreEqual(-1, exports.Test(-1.9));
+            Assert.AreEqual(-2, exports.Test(-2.0));
+            Assert.AreEqual(4294967296, exports.Test(4294967296));
+            Assert.AreEqual(-4294967296, exports.Test(-4294967296));
+            Assert.AreEqual(9223372036854774784, exports.Test(9223372036854774784.0));
+            Assert.AreEqual(-9223372036854775808, exports.Test(-9223372036854775808.0));
+            Assert.AreEqual(0x7fffffffffffffff, exports.Test(9223372036854775808.0));
+            Assert.AreEqual(unchecked((long)0x8000000000000000), exports.Test(-9223372036854777856.0));
+            Assert.AreEqual(0x7fffffffffffffff, exports.Test(double.PositiveInfinity));
+            Assert.AreEqual(unchecked((long)0x8000000000000000), exports.Test(double.NegativeInfinity));
+            Assert.AreEqual(0, exports.Test(double.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(double.NaN, 0x4000000000000)));
+            Assert.AreEqual(0, exports.Test(-double.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(-double.NaN, 0x4000000000000)));
+        }
+
+        private static double AddPayload(double doubleValue, long payload)
+        {
+            var doubleValueAsInt = BitConverter.DoubleToInt64Bits(doubleValue);
+            doubleValueAsInt |= payload;
+            return BitConverter.Int64BitsToDouble(doubleValueAsInt);
+        }
+    }
+}

--- a/WebAssembly.Tests/Instructions/Int64TruncateSaturateFloat64UnsignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int64TruncateSaturateFloat64UnsignedTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Tests the <see cref="Int64TruncateSaturateFloat64Unsigned"/> instruction.
+    /// </summary>
+    [TestClass]
+    public class Int64TruncateSaturateFloat64UnsignedTests
+    {
+        /// <summary>
+        /// Tests compilation and execution of the <see cref="Int64TruncateSaturateFloat64Unsigned"/> instruction.
+        /// </summary>
+        [TestMethod]
+        public void Int64TruncateSaturatedUnsignedFloat64_Compiled()
+        {
+            var exports = ConversionTestBase<double, long>.CreateInstance(
+                new LocalGet(0),
+                new Int64TruncateSaturateFloat64Unsigned(),
+                new End());
+
+            // Test cases from https://github.com/WebAssembly/spec/blob/7526564b56c30250b66504fe795e9c1e88a938af/test/core/conversions.wast
+            Assert.AreEqual(0, exports.Test(0.0));
+            Assert.AreEqual(0, exports.Test(-0.0));
+            Assert.AreEqual(0, exports.Test(double.Epsilon));
+            Assert.AreEqual(0, exports.Test(-double.Epsilon));
+            Assert.AreEqual(1, exports.Test(1.0));
+            Assert.AreEqual(1, exports.Test(BitConverter.Int64BitsToDouble(0x3ff199999999999a)));
+            Assert.AreEqual(1, exports.Test(1.5));
+            Assert.AreEqual(0xffffffff, exports.Test(4294967295));
+            Assert.AreEqual(0x100000000, exports.Test(4294967296));
+            Assert.AreEqual(-2048, exports.Test(18446744073709549568.0));
+            Assert.AreEqual(0, exports.Test(BitConverter.Int64BitsToDouble(unchecked((long)0xbfeccccccccccccd))));
+            Assert.AreEqual(0, exports.Test(BitConverter.Int64BitsToDouble(unchecked((long)0xbfefffffffffffff))));
+            Assert.AreEqual(100000000, exports.Test(1e8));
+            Assert.AreEqual(10000000000000000, exports.Test(1e16));
+            Assert.AreEqual(-9223372036854775808, exports.Test(9223372036854775808));
+            Assert.AreEqual(unchecked((long)0xffffffffffffffff), exports.Test(18446744073709551616.0));
+            Assert.AreEqual(0x0000000000000000, exports.Test(-1.0));
+            Assert.AreEqual(unchecked((long)0xffffffffffffffff), exports.Test(double.PositiveInfinity));
+            Assert.AreEqual(0x0000000000000000, exports.Test(double.NegativeInfinity));
+            Assert.AreEqual(0, exports.Test(double.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(double.NaN, 0x4000000000000)));
+            Assert.AreEqual(0, exports.Test(-double.NaN));
+            Assert.AreEqual(0, exports.Test(AddPayload(-double.NaN, 0x4000000000000)));
+        }
+
+        private static double AddPayload(double doubleValue, long payload)
+        {
+            var doubleValueAsInt = BitConverter.DoubleToInt64Bits(doubleValue);
+            doubleValueAsInt |= payload;
+            return BitConverter.Int64BitsToDouble(doubleValueAsInt);
+        }
+    }
+}

--- a/WebAssembly.Tests/OpCodeTests.cs
+++ b/WebAssembly.Tests/OpCodeTests.cs
@@ -61,6 +61,7 @@ namespace WebAssembly
                 { "max", "Maximum" },
                 { "copysign", "CopySign" },
                 { "const", "Constant" },
+                { "misc", "MiscellaneousOperationPrefix" },
             };
 
             foreach (var kv in opCodeCharacteristicsByOpCode)

--- a/WebAssembly/Instruction.cs
+++ b/WebAssembly/Instruction.cs
@@ -298,6 +298,23 @@ namespace WebAssembly
                     case OpCode.Int64Extend8Signed: yield return new Int64Extend8Signed(); break;
                     case OpCode.Int64Extend16Signed: yield return new Int64Extend16Signed(); break;
                     case OpCode.Int64Extend32Signed: yield return new Int64Extend32Signed(); break;
+
+                    case OpCode.MiscellaneousOperationPrefix:
+                        var miscellaneousOpCodeOffset = reader.Offset;
+                        var miscellaneousOpCode = (MiscellaneousOpCode)reader.ReadByte();
+                        switch (miscellaneousOpCode)
+                        {
+                            default: throw new ModuleLoadException($"Don't know how to parse miscellaneous opcode \"{miscellaneousOpCode}\".", miscellaneousOpCodeOffset);
+                            case MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed: yield return new Int32TruncateSaturateFloat32Signed(); break;
+                            case MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned: yield return new Int32TruncateSaturateFloat32Unsigned(); break;
+                            case MiscellaneousOpCode.Int32TruncateSaturateFloat64Signed: yield return new Int32TruncateSaturateFloat64Signed(); break;
+                            case MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned: yield return new Int32TruncateSaturateFloat64Unsigned(); break;
+                            case MiscellaneousOpCode.Int64TruncateSaturateFloat32Signed: yield return new Int64TruncateSaturateFloat32Signed(); break;
+                            case MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned: yield return new Int64TruncateSaturateFloat32Unsigned(); break;
+                            case MiscellaneousOpCode.Int64TruncateSaturateFloat64Signed: yield return new Int64TruncateSaturateFloat64Signed(); break;
+                            case MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned: yield return new Int64TruncateSaturateFloat64Unsigned(); break;
+                        }
+                        break;
                 }
             }
         }

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat32Signed.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat32Signed.cs
@@ -1,0 +1,79 @@
+﻿using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Truncate (with saturation) a 32-bit float to a signed 32-bit integer.
+    /// </summary>
+    public class Int32TruncateSaturateFloat32Signed : MiscellaneousInstruction
+    {
+        /// <summary>
+        /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed"/>.
+        /// </summary>
+        public override MiscellaneousOpCode MiscellaneousOpCode =>
+            MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int32TruncateSaturateFloat32Signed"/> instance.
+        /// </summary>
+        public Int32TruncateSaturateFloat32Signed()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count == 0)
+                throw new StackTooSmallException(MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed, 1, 0);
+
+            var type = stack.Pop();
+            if (type != WebAssemblyValueType.Float32)
+                throw new StackTypeInvalidException(MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed, WebAssemblyValueType.Float32, type);
+
+            context.Emit(OpCodes.Call, context[HelperMethod.Int32TruncateSaturateFloat32Signed, (helper, c) =>
+            {
+                var builder = c.CheckedExportsBuilder.DefineMethod(
+                    "☣ Int32TruncateSaturateFloat32Signed",
+                    CompilationContext.HelperMethodAttributes,
+                    typeof(int),
+                    new[] { typeof(float) }
+                );
+
+                var il = builder.GetILGenerator();
+
+                var label1 = il.DefineLabel();
+                var label2 = il.DefineLabel();
+                var label3 = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R4, 2.1474836E+09f);
+                il.Emit(OpCodes.Blt_Un_S, label1);
+                il.Emit(OpCodes.Ldc_I4, 2147483647);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R4, -2.1474836E+09f);
+                il.Emit(OpCodes.Bgt_Un_S, label2);
+                il.Emit(OpCodes.Ldc_I4, -2147483648);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label2);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Call, typeof(float).GetMethod("IsNaN")!, null);
+                il.Emit(OpCodes.Brfalse_S, label3);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label3);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Conv_I4);
+                il.Emit(OpCodes.Ret);
+
+                return builder;
+            }
+            ]);
+
+            stack.Push(WebAssemblyValueType.Int32);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat32Signed.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat32Signed.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Instructions
         /// <summary>
         /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed"/>.
         /// </summary>
-        public override MiscellaneousOpCode MiscellaneousOpCode =>
+        public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
             MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed;
 
         /// <summary>

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat32Unsigned.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Instructions
         /// <summary>
         /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned"/>.
         /// </summary>
-        public override MiscellaneousOpCode MiscellaneousOpCode =>
+        public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
             MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned;
 
         /// <summary>

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat32Unsigned.cs
@@ -1,0 +1,79 @@
+﻿using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Truncate (with saturation) a 32-bit float to an unsigned 32-bit integer.
+    /// </summary>
+    public class Int32TruncateSaturateFloat32Unsigned : MiscellaneousInstruction
+    {
+        /// <summary>
+        /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned"/>.
+        /// </summary>
+        public override MiscellaneousOpCode MiscellaneousOpCode =>
+            MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int32TruncateSaturateFloat32Unsigned"/> instance.
+        /// </summary>
+        public Int32TruncateSaturateFloat32Unsigned()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count == 0)
+                throw new StackTooSmallException(MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned, 1, 0);
+
+            var type = stack.Pop();
+            if (type != WebAssemblyValueType.Float32)
+                throw new StackTypeInvalidException(MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned, WebAssemblyValueType.Float32, type);
+
+            context.Emit(OpCodes.Call, context[HelperMethod.Int32TruncateSaturateFloat32Unsigned, (helper, c) =>
+            {
+                var builder = c.CheckedExportsBuilder.DefineMethod(
+                    "☣ Int32TruncateSaturateFloat32Unsigned",
+                    CompilationContext.HelperMethodAttributes,
+                    typeof(uint),
+                    new[] { typeof(float) }
+                );
+
+                var il = builder.GetILGenerator();
+
+                var label1 = il.DefineLabel();
+                var label2 = il.DefineLabel();
+                var label3 = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R4, 4.2949673E+09f);
+                il.Emit(OpCodes.Blt_Un_S, label1);
+                il.Emit(OpCodes.Ldc_I4_M1);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R4, 0.0f);
+                il.Emit(OpCodes.Bgt_Un_S, label2);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label2);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Call, typeof(float).GetMethod("IsNaN")!, null);
+                il.Emit(OpCodes.Brfalse_S, label3);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label3);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Conv_U4);
+                il.Emit(OpCodes.Ret);
+
+                return builder;
+            }
+            ]);
+
+            stack.Push(WebAssemblyValueType.Int32);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat64Signed.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat64Signed.cs
@@ -1,0 +1,79 @@
+﻿using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Truncate (with saturation) a 64-bit float to a signed 32-bit integer.
+    /// </summary>
+    public class Int32TruncateSaturateFloat64Signed : MiscellaneousInstruction
+    {
+        /// <summary>
+        /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat64Signed"/>.
+        /// </summary>
+        public override MiscellaneousOpCode MiscellaneousOpCode =>
+            MiscellaneousOpCode.Int32TruncateSaturateFloat64Signed;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int32TruncateSaturateFloat64Signed"/> instance.
+        /// </summary>
+        public Int32TruncateSaturateFloat64Signed()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count == 0)
+                throw new StackTooSmallException(MiscellaneousOpCode.Int32TruncateSaturateFloat64Signed, 1, 0);
+
+            var type = stack.Pop();
+            if (type != WebAssemblyValueType.Float64)
+                throw new StackTypeInvalidException(MiscellaneousOpCode.Int32TruncateSaturateFloat64Signed, WebAssemblyValueType.Float64, type);
+
+            context.Emit(OpCodes.Call, context[HelperMethod.Int32TruncateSaturateFloat64Signed, (helper, c) =>
+            {
+                var builder = c.CheckedExportsBuilder.DefineMethod(
+                    "☣ Int32TruncateSaturateFloat64Signed",
+                    CompilationContext.HelperMethodAttributes,
+                    typeof(int),
+                    new[] { typeof(double) }
+                );
+
+                var il = builder.GetILGenerator();
+
+                var label1 = il.DefineLabel();
+                var label2 = il.DefineLabel();
+                var label3 = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R8, 2147483647.0);
+                il.Emit(OpCodes.Blt_Un_S, label1);
+                il.Emit(OpCodes.Ldc_I4, 2147483647);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R8, -2147483648.0);
+                il.Emit(OpCodes.Bgt_Un_S, label2);
+                il.Emit(OpCodes.Ldc_I4, -2147483648);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label2);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Call, typeof(double).GetMethod("IsNaN")!, null);
+                il.Emit(OpCodes.Brfalse_S, label3);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label3);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Conv_I4);
+                il.Emit(OpCodes.Ret);
+
+                return builder;
+            }
+            ]);
+
+            stack.Push(WebAssemblyValueType.Int32);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat64Signed.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat64Signed.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Instructions
         /// <summary>
         /// Always <see cref="Int32TruncateSaturateFloat64Signed"/>.
         /// </summary>
-        public override MiscellaneousOpCode MiscellaneousOpCode =>
+        public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
             MiscellaneousOpCode.Int32TruncateSaturateFloat64Signed;
 
         /// <summary>

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat64Unsigned.cs
@@ -1,0 +1,79 @@
+﻿using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Truncate (with saturation) a 64-bit float to an unsigned 32-bit integer.
+    /// </summary>
+    public class Int32TruncateSaturateFloat64Unsigned : MiscellaneousInstruction
+    {
+        /// <summary>
+        /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned"/>.
+        /// </summary>
+        public override MiscellaneousOpCode MiscellaneousOpCode =>
+            MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int32TruncateSaturateFloat64Unsigned"/> instance.
+        /// </summary>
+        public Int32TruncateSaturateFloat64Unsigned()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count == 0)
+                throw new StackTooSmallException(MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned, 1, 0);
+
+            var type = stack.Pop();
+            if (type != WebAssemblyValueType.Float64)
+                throw new StackTypeInvalidException(MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned, WebAssemblyValueType.Float64, type);
+
+            context.Emit(OpCodes.Call, context[HelperMethod.Int32TruncateSaturateFloat64Unsigned, (helper, c) =>
+            {
+                var builder = c.CheckedExportsBuilder.DefineMethod(
+                    "☣ Int32TruncateSaturateFloat64Unsigned",
+                    CompilationContext.HelperMethodAttributes,
+                    typeof(uint),
+                    new[] { typeof(double) }
+                );
+
+                var il = builder.GetILGenerator();
+
+                var label1 = il.DefineLabel();
+                var label2 = il.DefineLabel();
+                var label3 = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R8, 4294967295.0);
+                il.Emit(OpCodes.Blt_Un_S, label1);
+                il.Emit(OpCodes.Ldc_I4_M1);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R8, 0.0);
+                il.Emit(OpCodes.Bgt_Un_S, label2);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label2);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Call, typeof(double).GetMethod("IsNaN")!, null);
+                il.Emit(OpCodes.Brfalse_S, label3);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label3);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Conv_U4);
+                il.Emit(OpCodes.Ret);
+
+                return builder;
+            }
+            ]);
+
+            stack.Push(WebAssemblyValueType.Int32);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat64Unsigned.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Instructions
         /// <summary>
         /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned"/>.
         /// </summary>
-        public override MiscellaneousOpCode MiscellaneousOpCode =>
+        public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
             MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned;
 
         /// <summary>

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat64Unsigned.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection.Emit;
-using WebAssembly.Runtime;
+﻿using System;
+using System.Reflection.Emit;
 using WebAssembly.Runtime.Compilation;
 
 namespace WebAssembly.Instructions
@@ -7,7 +7,7 @@ namespace WebAssembly.Instructions
     /// <summary>
     /// Truncate (with saturation) a 64-bit float to an unsigned 32-bit integer.
     /// </summary>
-    public class Int32TruncateSaturateFloat64Unsigned : MiscellaneousInstruction
+    public class Int32TruncateSaturateFloat64Unsigned : TruncateSaturateInstruction
     {
         /// <summary>
         /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned"/>.
@@ -22,58 +22,40 @@ namespace WebAssembly.Instructions
         {
         }
 
-        internal sealed override void Compile(CompilationContext context)
+        private protected override WebAssemblyValueType InputValueType => WebAssemblyValueType.Float64;
+        private protected override WebAssemblyValueType OutputValueType => WebAssemblyValueType.Int32;
+        private protected override Type InputType => typeof(double);
+        private protected override Type OutputType => typeof(uint);
+        private protected override HelperMethod ConversionHelper => HelperMethod.Int32TruncateSaturateFloat64Unsigned;
+
+        private protected override void EmitLoadFloatMaxValue(ILGenerator il)
         {
-            var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned, 1, 0);
+            il.Emit(OpCodes.Ldc_R8, (double)uint.MaxValue);
+        }
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float64)
-                throw new StackTypeInvalidException(MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned, WebAssemblyValueType.Float64, type);
+        private protected override void EmitLoadIntegerMaxValue(ILGenerator il)
+        {
+            il.Emit(OpCodes.Ldc_I4_M1);
+        }
 
-            context.Emit(OpCodes.Call, context[HelperMethod.Int32TruncateSaturateFloat64Unsigned, (helper, c) =>
-            {
-                var builder = c.CheckedExportsBuilder.DefineMethod(
-                    "☣ Int32TruncateSaturateFloat64Unsigned",
-                    CompilationContext.HelperMethodAttributes,
-                    typeof(uint),
-                    new[] { typeof(double) }
-                );
+        private protected override void EmitLoadFloatMinValue(ILGenerator il)
+        {
+            il.Emit(OpCodes.Ldc_R8, 0.0);
+        }
 
-                var il = builder.GetILGenerator();
+        private protected override void EmitLoadIntegerMinValue(ILGenerator il)
+        {
+            il.Emit(OpCodes.Ldc_I4_0);
+        }
 
-                var label1 = il.DefineLabel();
-                var label2 = il.DefineLabel();
-                var label3 = il.DefineLabel();
+        private protected override void EmitLoadIntegerZero(ILGenerator il)
+        {
+            il.Emit(OpCodes.Ldc_I4_0);
+        }
 
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldc_R8, 4294967295.0);
-                il.Emit(OpCodes.Blt_Un_S, label1);
-                il.Emit(OpCodes.Ldc_I4_M1);
-                il.Emit(OpCodes.Ret);
-                il.MarkLabel(label1);
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldc_R8, 0.0);
-                il.Emit(OpCodes.Bgt_Un_S, label2);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ret);
-                il.MarkLabel(label2);
-                il.Emit(OpCodes.Ldarg_0);
-                il.EmitCall(OpCodes.Call, typeof(double).GetMethod("IsNaN")!, null);
-                il.Emit(OpCodes.Brfalse_S, label3);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ret);
-                il.MarkLabel(label3);
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Conv_U4);
-                il.Emit(OpCodes.Ret);
-
-                return builder;
-            }
-            ]);
-
-            stack.Push(WebAssemblyValueType.Int32);
+        private protected override void EmitConvert(ILGenerator il)
+        {
+            il.Emit(OpCodes.Conv_U4);
         }
     }
 }

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat32Signed.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat32Signed.cs
@@ -1,0 +1,80 @@
+﻿using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Truncate (with saturation) a 32-bit float to a signed 64-bit integer.
+    /// </summary>
+    public class Int64TruncateSaturateFloat32Signed : MiscellaneousInstruction
+    {
+        /// <summary>
+        /// Always <see cref="MiscellaneousOpCode.Int64TruncateSaturateFloat32Signed"/>.
+        /// </summary>
+        public override MiscellaneousOpCode MiscellaneousOpCode =>
+            MiscellaneousOpCode.Int64TruncateSaturateFloat32Signed;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int64TruncateSaturateFloat32Signed"/> instance.
+        /// </summary>
+        public Int64TruncateSaturateFloat32Signed()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count == 0)
+                throw new StackTooSmallException(MiscellaneousOpCode.Int64TruncateSaturateFloat32Signed, 1, 0);
+
+            var type = stack.Pop();
+            if (type != WebAssemblyValueType.Float32)
+                throw new StackTypeInvalidException(MiscellaneousOpCode.Int64TruncateSaturateFloat32Signed, WebAssemblyValueType.Float32, type);
+
+            context.Emit(OpCodes.Call, context[HelperMethod.Int64TruncateSaturateFloat32Signed, (helper, c) =>
+            {
+                var builder = c.CheckedExportsBuilder.DefineMethod(
+                    "☣ Int64TruncateSaturateFloat32Signed",
+                    CompilationContext.HelperMethodAttributes,
+                    typeof(long),
+                    new[] { typeof(float) }
+                );
+
+                var il = builder.GetILGenerator();
+
+                var label1 = il.DefineLabel();
+                var label2 = il.DefineLabel();
+                var label3 = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R4, 9.223372E+18f);
+                il.Emit(OpCodes.Blt_Un_S, label1);
+                il.Emit(OpCodes.Ldc_I8, 9223372036854775807);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R4, -9.223372E+18f);
+                il.Emit(OpCodes.Bgt_Un_S, label2);
+                il.Emit(OpCodes.Ldc_I8, -9223372036854775808);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label2);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Call, typeof(float).GetMethod("IsNaN")!, null);
+                il.Emit(OpCodes.Brfalse_S, label3);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label3);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+
+                return builder;
+            }
+            ]);
+
+            stack.Push(WebAssemblyValueType.Int64);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat32Signed.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat32Signed.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Instructions
         /// <summary>
         /// Always <see cref="Int64TruncateSaturateFloat32Signed"/>.
         /// </summary>
-        public override MiscellaneousOpCode MiscellaneousOpCode =>
+        public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
             MiscellaneousOpCode.Int64TruncateSaturateFloat32Signed;
 
         /// <summary>

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat32Unsigned.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Instructions
         /// <summary>
         /// Always <see cref="MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned"/>.
         /// </summary>
-        public override MiscellaneousOpCode MiscellaneousOpCode =>
+        public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
             MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned;
 
         /// <summary>

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat32Unsigned.cs
@@ -1,0 +1,82 @@
+﻿using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Truncate (with saturation) a 32-bit float to an unsigned 64-bit integer.
+    /// </summary>
+    public class Int64TruncateSaturateFloat32Unsigned : MiscellaneousInstruction
+    {
+        /// <summary>
+        /// Always <see cref="MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned"/>.
+        /// </summary>
+        public override MiscellaneousOpCode MiscellaneousOpCode =>
+            MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int64TruncateSaturateFloat32Unsigned"/> instance.
+        /// </summary>
+        public Int64TruncateSaturateFloat32Unsigned()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count == 0)
+                throw new StackTooSmallException(MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned, 1, 0);
+
+            var type = stack.Pop();
+            if (type != WebAssemblyValueType.Float32)
+                throw new StackTypeInvalidException(MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned, WebAssemblyValueType.Float32, type);
+
+            context.Emit(OpCodes.Call, context[HelperMethod.Int64TruncateSaturateFloat32Unsigned, (helper, c) =>
+            {
+                var builder = c.CheckedExportsBuilder.DefineMethod(
+                    "☣ Int64TruncateSaturateFloat32Unsigned",
+                    CompilationContext.HelperMethodAttributes,
+                    typeof(ulong),
+                    new[] { typeof(float) }
+                );
+
+                var il = builder.GetILGenerator();
+
+                var label1 = il.DefineLabel();
+                var label2 = il.DefineLabel();
+                var label3 = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R4, 1.8446744E+19f);
+                il.Emit(OpCodes.Blt_Un_S, label1);
+                il.Emit(OpCodes.Ldc_I4_M1);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R4, 0.0f);
+                il.Emit(OpCodes.Bgt_Un_S, label2);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label2);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Call, typeof(float).GetMethod("IsNaN")!, null);
+                il.Emit(OpCodes.Brfalse_S, label3);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label3);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Conv_U8);
+                il.Emit(OpCodes.Ret);
+
+                return builder;
+            }
+            ]);
+
+            stack.Push(WebAssemblyValueType.Int64);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat32Unsigned.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection.Emit;
-using WebAssembly.Runtime;
+﻿using System;
+using System.Reflection.Emit;
 using WebAssembly.Runtime.Compilation;
 
 namespace WebAssembly.Instructions
@@ -7,7 +7,7 @@ namespace WebAssembly.Instructions
     /// <summary>
     /// Truncate (with saturation) a 32-bit float to an unsigned 64-bit integer.
     /// </summary>
-    public class Int64TruncateSaturateFloat32Unsigned : MiscellaneousInstruction
+    public class Int64TruncateSaturateFloat32Unsigned : TruncateSaturateInstruction
     {
         /// <summary>
         /// Always <see cref="MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned"/>.
@@ -22,61 +22,43 @@ namespace WebAssembly.Instructions
         {
         }
 
-        internal sealed override void Compile(CompilationContext context)
+        private protected override WebAssemblyValueType InputValueType => WebAssemblyValueType.Float32;
+        private protected override WebAssemblyValueType OutputValueType => WebAssemblyValueType.Int64;
+        private protected override Type InputType => typeof(float);
+        private protected override Type OutputType => typeof(ulong);
+        private protected override HelperMethod ConversionHelper => HelperMethod.Int64TruncateSaturateFloat32Unsigned;
+
+        private protected override void EmitLoadFloatMaxValue(ILGenerator il)
         {
-            var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned, 1, 0);
+            il.Emit(OpCodes.Ldc_R4, (float)ulong.MaxValue);
+        }
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned, WebAssemblyValueType.Float32, type);
+        private protected override void EmitLoadIntegerMaxValue(ILGenerator il)
+        {
+            il.Emit(OpCodes.Ldc_I4_M1);
+            il.Emit(OpCodes.Conv_I8);
+        }
 
-            context.Emit(OpCodes.Call, context[HelperMethod.Int64TruncateSaturateFloat32Unsigned, (helper, c) =>
-            {
-                var builder = c.CheckedExportsBuilder.DefineMethod(
-                    "☣ Int64TruncateSaturateFloat32Unsigned",
-                    CompilationContext.HelperMethodAttributes,
-                    typeof(ulong),
-                    new[] { typeof(float) }
-                );
+        private protected override void EmitLoadFloatMinValue(ILGenerator il)
+        {
+            il.Emit(OpCodes.Ldc_R4, 0.0f);
+        }
 
-                var il = builder.GetILGenerator();
+        private protected override void EmitLoadIntegerMinValue(ILGenerator il)
+        {
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Conv_I8);
+        }
 
-                var label1 = il.DefineLabel();
-                var label2 = il.DefineLabel();
-                var label3 = il.DefineLabel();
+        private protected override void EmitLoadIntegerZero(ILGenerator il)
+        {
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Conv_I8);
+        }
 
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldc_R4, 1.8446744E+19f);
-                il.Emit(OpCodes.Blt_Un_S, label1);
-                il.Emit(OpCodes.Ldc_I4_M1);
-                il.Emit(OpCodes.Conv_I8);
-                il.Emit(OpCodes.Ret);
-                il.MarkLabel(label1);
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldc_R4, 0.0f);
-                il.Emit(OpCodes.Bgt_Un_S, label2);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Conv_I8);
-                il.Emit(OpCodes.Ret);
-                il.MarkLabel(label2);
-                il.Emit(OpCodes.Ldarg_0);
-                il.EmitCall(OpCodes.Call, typeof(float).GetMethod("IsNaN")!, null);
-                il.Emit(OpCodes.Brfalse_S, label3);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Conv_I8);
-                il.Emit(OpCodes.Ret);
-                il.MarkLabel(label3);
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Conv_U8);
-                il.Emit(OpCodes.Ret);
-
-                return builder;
-            }
-            ]);
-
-            stack.Push(WebAssemblyValueType.Int64);
+        private protected override void EmitConvert(ILGenerator il)
+        {
+            il.Emit(OpCodes.Conv_U8);
         }
     }
 }

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat64Signed.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat64Signed.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Instructions
         /// <summary>
         /// Always <see cref="Int64TruncateSaturateFloat64Signed"/>.
         /// </summary>
-        public override MiscellaneousOpCode MiscellaneousOpCode =>
+        public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
             MiscellaneousOpCode.Int64TruncateSaturateFloat64Signed;
 
         /// <summary>

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat64Signed.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat64Signed.cs
@@ -1,0 +1,80 @@
+﻿using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Truncate (with saturation) a 64-bit float to a signed 64-bit integer.
+    /// </summary>
+    public class Int64TruncateSaturateFloat64Signed : MiscellaneousInstruction
+    {
+        /// <summary>
+        /// Always <see cref="MiscellaneousOpCode.Int64TruncateSaturateFloat64Signed"/>.
+        /// </summary>
+        public override MiscellaneousOpCode MiscellaneousOpCode =>
+            MiscellaneousOpCode.Int64TruncateSaturateFloat64Signed;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int64TruncateSaturateFloat64Signed"/> instance.
+        /// </summary>
+        public Int64TruncateSaturateFloat64Signed()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count == 0)
+                throw new StackTooSmallException(MiscellaneousOpCode.Int64TruncateSaturateFloat64Signed, 1, 0);
+
+            var type = stack.Pop();
+            if (type != WebAssemblyValueType.Float64)
+                throw new StackTypeInvalidException(MiscellaneousOpCode.Int64TruncateSaturateFloat64Signed, WebAssemblyValueType.Float64, type);
+
+            context.Emit(OpCodes.Call, context[HelperMethod.Int64TruncateSaturateFloat64Signed, (helper, c) =>
+            {
+                var builder = c.CheckedExportsBuilder.DefineMethod(
+                    "☣ Int64TruncateSaturateFloat64Signed",
+                    CompilationContext.HelperMethodAttributes,
+                    typeof(long),
+                    new[] { typeof(double) }
+                );
+
+                var il = builder.GetILGenerator();
+
+                var label1 = il.DefineLabel();
+                var label2 = il.DefineLabel();
+                var label3 = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R8, 9.223372036854776E+18);
+                il.Emit(OpCodes.Blt_Un_S, label1);
+                il.Emit(OpCodes.Ldc_I8, 9223372036854775807);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R8, -9.223372036854776E+18);
+                il.Emit(OpCodes.Bgt_Un_S, label2);
+                il.Emit(OpCodes.Ldc_I8, -9223372036854775808);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label2);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Call, typeof(double).GetMethod("IsNaN")!, null);
+                il.Emit(OpCodes.Brfalse_S, label3);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label3);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+
+                return builder;
+            }
+            ]);
+
+            stack.Push(WebAssemblyValueType.Int64);
+        }
+    }
+}

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat64Unsigned.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection.Emit;
-using WebAssembly.Runtime;
 using WebAssembly.Runtime.Compilation;
 
 namespace WebAssembly.Instructions
@@ -13,7 +12,7 @@ namespace WebAssembly.Instructions
         /// <summary>
         /// Always <see cref="MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned"/>.
         /// </summary>
-        public override MiscellaneousOpCode MiscellaneousOpCode =>
+        public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
             MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned;
 
         /// <summary>

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat64Unsigned.cs
@@ -1,0 +1,82 @@
+﻿using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Truncate (with saturation) a 64-bit float to an unsigned 64-bit integer.
+    /// </summary>
+    public class Int64TruncateSaturateFloat64Unsigned : MiscellaneousInstruction
+    {
+        /// <summary>
+        /// Always <see cref="MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned"/>.
+        /// </summary>
+        public override MiscellaneousOpCode MiscellaneousOpCode =>
+            MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned;
+
+        /// <summary>
+        /// Creates a new  <see cref="Int64TruncateSaturateFloat64Unsigned"/> instance.
+        /// </summary>
+        public Int64TruncateSaturateFloat64Unsigned()
+        {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count == 0)
+                throw new StackTooSmallException(MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned, 1, 0);
+
+            var type = stack.Pop();
+            if (type != WebAssemblyValueType.Float64)
+                throw new StackTypeInvalidException(MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned, WebAssemblyValueType.Float64, type);
+
+            context.Emit(OpCodes.Call, context[HelperMethod.Int64TruncateSaturateFloat64Unsigned, (helper, c) =>
+            {
+                var builder = c.CheckedExportsBuilder.DefineMethod(
+                    "☣ Int64TruncateSaturateFloat64Unsigned",
+                    CompilationContext.HelperMethodAttributes,
+                    typeof(ulong),
+                    new[] { typeof(double) }
+                );
+
+                var il = builder.GetILGenerator();
+
+                var label1 = il.DefineLabel();
+                var label2 = il.DefineLabel();
+                var label3 = il.DefineLabel();
+
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R8, 1.8446744073709552E+19);
+                il.Emit(OpCodes.Blt_Un_S, label1);
+                il.Emit(OpCodes.Ldc_I4_M1);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldc_R8, 0.0);
+                il.Emit(OpCodes.Bgt_Un_S, label2);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label2);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Call, typeof(double).GetMethod("IsNaN")!, null);
+                il.Emit(OpCodes.Brfalse_S, label3);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Conv_I8);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(label3);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Conv_U8);
+                il.Emit(OpCodes.Ret);
+
+                return builder;
+            }
+            ]);
+
+            stack.Push(WebAssemblyValueType.Int64);
+        }
+    }
+}

--- a/WebAssembly/Instructions/MiscellaneousInstruction.cs
+++ b/WebAssembly/Instructions/MiscellaneousInstruction.cs
@@ -1,0 +1,51 @@
+﻿namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Miscellaneous instructions have a prefix byte 0xfc; they are defined by the combination of their <see cref="OpCode"/> and <see cref="MiscellaneousOpCode"/>.
+    /// </summary>
+    public abstract class MiscellaneousInstruction : Instruction
+    {
+        private protected MiscellaneousInstruction()
+        {
+        }
+
+        /// <summary>
+        /// Always <see cref="OpCode.MiscellaneousOperationPrefix"/>.
+        /// </summary>
+        public sealed override OpCode OpCode => OpCode.MiscellaneousOperationPrefix;
+
+        /// <summary>
+        /// Gets the <see cref="MiscellaneousOpCode"/> associated with this instruction.
+        /// </summary>
+        public abstract MiscellaneousOpCode MiscellaneousOpCode { get; }
+
+        internal sealed override void WriteTo(Writer writer)
+        {
+            writer.Write((byte)this.OpCode);
+            writer.Write((byte)this.MiscellaneousOpCode);
+        }
+
+        /// <summary>
+        /// Determines whether this instruction is identical to another.
+        /// </summary>
+        /// <param name="other">The instruction to compare against.</param>
+        /// <returns>True if they have the same type and value, otherwise false.</returns>
+        public override bool Equals(Instruction? other) => 
+            other is MiscellaneousInstruction instruction
+            && instruction.OpCode == this.OpCode 
+            && instruction.MiscellaneousOpCode == this.MiscellaneousOpCode
+            ;
+
+        /// <summary>
+        /// Returns the integer representation of <see cref="Instruction.OpCode"/> as a hash code.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        public override int GetHashCode() => HashCode.Combine((int)this.OpCode, (int)this.MiscellaneousOpCode);
+
+        /// <summary>
+        /// Provides a native representation of the instruction.
+        /// </summary>
+        /// <returns>A string representation of this instance.</returns>
+        public sealed override string ToString() => this.MiscellaneousOpCode.ToNativeName();
+    }
+}

--- a/WebAssembly/Instructions/TruncateSaturateInstruction.cs
+++ b/WebAssembly/Instructions/TruncateSaturateInstruction.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Reflection.Emit;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions
+{
+    /// <summary>
+    /// Provides shared functionality for instructions that do truncation with saturation.
+    /// </summary>
+    public abstract class TruncateSaturateInstruction : MiscellaneousInstruction
+    {
+        private protected TruncateSaturateInstruction()
+            : base()
+        {
+        }
+
+        private protected abstract WebAssemblyValueType InputValueType { get; }
+        private protected abstract WebAssemblyValueType OutputValueType { get; }
+        private protected abstract HelperMethod ConversionHelper { get; }
+        private protected abstract Type InputType { get; }
+        private protected abstract Type OutputType { get; }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            var stack = context.Stack;
+            if (stack.Count == 0)
+                throw new StackTooSmallException(MiscellaneousOpCode, 1, 0);
+
+            var type = stack.Pop();
+            if (type != InputValueType)
+                throw new StackTypeInvalidException(MiscellaneousOpCode, InputValueType, type);
+
+            context.Emit(OpCodes.Call, context[ConversionHelper, (helper, c) =>
+            {
+                var builder = c.CheckedExportsBuilder.DefineMethod(
+                    $"☣ {ConversionHelper}",
+                    CompilationContext.HelperMethodAttributes,
+                    OutputType,
+                    new[] { InputType }
+                );
+
+                // The following code is an IL version of this C#,
+                // with "float" and "int" replaced by "double" and "uint"
+                // as appropriate for the overriding class:
+                //
+                // public static int Int32TruncateSaturateFloat32Signed(float f)
+                // {
+                //     if (f >= int.MaxValue)
+                //         return int.MaxValue;
+                // 
+                //     if (f <= int.MinValue)
+                //         return int.MinValue;
+                // 
+                //     if (float.IsNaN(f))
+                //         return 0;
+                // 
+                //     return (int)f;
+                // }
+
+                var il = builder.GetILGenerator();
+
+                var notAboveRangeLabel = il.DefineLabel();
+                var notBelowRangeLabel = il.DefineLabel();
+                var notNaNLabel = il.DefineLabel();
+
+                // if (f >= int.MaxValue)
+                il.Emit(OpCodes.Ldarg_0);
+                EmitLoadFloatMaxValue(il);
+                il.Emit(OpCodes.Blt_Un_S, notAboveRangeLabel);
+
+                // return int.MaxValue
+                EmitLoadIntegerMaxValue(il);
+                il.Emit(OpCodes.Ret);
+
+                // if (f <= int.MinValue)
+                il.MarkLabel(notAboveRangeLabel);
+                il.Emit(OpCodes.Ldarg_0);
+                EmitLoadFloatMinValue(il);
+                il.Emit(OpCodes.Bgt_Un_S, notBelowRangeLabel);
+
+                // return int.MinValue
+                EmitLoadIntegerMinValue(il);
+                il.Emit(OpCodes.Ret);
+
+                // if (float.IsNaN(f))
+                il.MarkLabel(notBelowRangeLabel);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Call, InputType.GetMethod(nameof(float.IsNaN))!, null);
+                il.Emit(OpCodes.Brfalse_S, notNaNLabel);
+
+                // return 0
+                EmitLoadIntegerZero(il);
+                il.Emit(OpCodes.Ret);
+
+                // return (int)f
+                il.MarkLabel(notNaNLabel);
+                il.Emit(OpCodes.Ldarg_0);
+                EmitConvert(il);
+                il.Emit(OpCodes.Ret);
+
+                return builder;
+            }
+            ]);
+
+            stack.Push(OutputValueType);
+        }
+
+        private protected abstract void EmitLoadFloatMaxValue(ILGenerator il);
+        private protected abstract void EmitLoadIntegerMaxValue(ILGenerator il);
+        private protected abstract void EmitLoadFloatMinValue(ILGenerator il);
+        private protected abstract void EmitLoadIntegerMinValue(ILGenerator il);
+        private protected abstract void EmitLoadIntegerZero(ILGenerator il);
+        private protected abstract void EmitConvert(ILGenerator il);
+    }
+}

--- a/WebAssembly/MiscellaneousOpCode.cs
+++ b/WebAssembly/MiscellaneousOpCode.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace WebAssembly
+{
+    /// <summary>
+    /// Binary miscellaneous operation values.
+    /// </summary>
+    public enum MiscellaneousOpCode : byte
+    {
+        /// <summary>
+        /// Truncate (with saturation) a 32-bit float to a signed 32-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i32.trunc_sat_f32_s")]
+        Int32TruncateSaturateFloat32Signed = 0x00,
+
+        /// <summary>
+        /// Truncate (with saturation) a 32-bit float to an unsigned 32-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i32.trunc_sat_f32_u")]
+        Int32TruncateSaturateFloat32Unsigned = 0x01,
+
+        /// <summary>
+        /// Truncate (with saturation) a 64-bit float to a signed 32-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i32.trunc_sat_f64_s")]
+        Int32TruncateSaturateFloat64Signed = 0x02,
+
+        /// <summary>
+        /// Truncate (with saturation) a 64-bit float to an unsigned 32-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i32.trunc_sat_f64_u")]
+        Int32TruncateSaturateFloat64Unsigned = 0x03,
+
+        /// <summary>
+        /// Truncate (with saturation) a 32-bit float to a signed 64-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i64.trunc_sat_f32_s")]
+        Int64TruncateSaturateFloat32Signed = 0x04,
+
+        /// <summary>
+        /// Truncate (with saturation) a 32-bit float to an unsigned 64-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i64.trunc_sat_f32_u")]
+        Int64TruncateSaturateFloat32Unsigned = 0x05,
+
+        /// <summary>
+        /// Truncate (with saturation) a 64-bit float to a signed 64-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i64.trunc_sat_f64_s")]
+        Int64TruncateSaturateFloat64Signed = 0x06,
+
+        /// <summary>
+        /// Truncate (with saturation) a 64-bit float to an unsigned 64-bit integer.
+        /// </summary>
+        [OpCodeCharacteristics("i64.trunc_sat_f64_u")]
+        Int64TruncateSaturateFloat64Unsigned = 0x07,
+    }
+
+    static class MiscellaneousOpCodeExtensions
+    {
+        private static readonly RegeneratingWeakReference<Dictionary<MiscellaneousOpCode, string>> opCodeNativeNamesByOpCode = new RegeneratingWeakReference<Dictionary<MiscellaneousOpCode, string>>(
+            () => typeof(MiscellaneousOpCode)
+                .GetFields()
+                .Where(field => field.IsStatic)
+                .Select(field => new KeyValuePair<MiscellaneousOpCode, string>((MiscellaneousOpCode)field.GetValue(null)!, field.GetCustomAttribute<OpCodeCharacteristicsAttribute>()!.Name))
+                .ToDictionary(kv => kv.Key, kv => kv.Value)
+        );
+
+        public static string ToNativeName(this MiscellaneousOpCode opCode)
+        {
+            opCodeNativeNamesByOpCode.Reference.TryGetValue(opCode, out var result);
+            return result!;
+        }
+    }
+}

--- a/WebAssembly/OpCode.cs
+++ b/WebAssembly/OpCode.cs
@@ -1071,6 +1071,12 @@ namespace WebAssembly
         /// </summary>
         [OpCodeCharacteristics("i64.extend32_s")]
         Int64Extend32Signed = 0xc4,
+
+        /// <summary>
+        /// Prefix byte for miscellaneous operations.
+        /// </summary>
+        [OpCodeCharacteristics("misc")]
+        MiscellaneousOperationPrefix = 0xfc,
     }
 
     static class OpCodeExtensions

--- a/WebAssembly/Runtime/Compilation/HelperMethod.cs
+++ b/WebAssembly/Runtime/Compilation/HelperMethod.cs
@@ -36,5 +36,13 @@
         Int32RotateRight,
         Int64RotateLeft,
         Int64RotateRight,
+        Int32TruncateSaturateFloat32Signed,
+        Int32TruncateSaturateFloat32Unsigned,
+        Int32TruncateSaturateFloat64Signed,
+        Int32TruncateSaturateFloat64Unsigned,
+        Int64TruncateSaturateFloat32Signed,
+        Int64TruncateSaturateFloat32Unsigned,
+        Int64TruncateSaturateFloat64Signed,
+        Int64TruncateSaturateFloat64Unsigned,
     }
 }

--- a/WebAssembly/Runtime/OpCodeCompilationException.cs
+++ b/WebAssembly/Runtime/OpCodeCompilationException.cs
@@ -17,8 +17,25 @@
         }
 
         /// <summary>
+        /// Creates a new <see cref="OpCodeCompilationException"/> with the provided parameters.
+        /// </summary>
+        /// <param name="miscellaneousOpCode">The miscellaneous operation attempted.</param>
+        /// <param name="message">An explanation of the problem, concatenated with <paramref name="miscellaneousOpCode"/> and passed to the base as the message.</param>
+        public OpCodeCompilationException(MiscellaneousOpCode miscellaneousOpCode, string message)
+            : base($"{miscellaneousOpCode} {message}")
+        {
+            this.OpCode = OpCode.MiscellaneousOperationPrefix;
+            this.MiscellaneousOpCode = miscellaneousOpCode;
+        }
+
+        /// <summary>
         /// The operation attempted.
         /// </summary>
         public OpCode OpCode { get; }
+
+        /// <summary>
+        /// The miscellaneous operation attempted, if <see cref="OpCode"/> is <see cref="OpCode.MiscellaneousOperationPrefix"/>.
+        /// </summary>
+        public MiscellaneousOpCode? MiscellaneousOpCode { get; }
     }
 }

--- a/WebAssembly/Runtime/StackTooSmallException.cs
+++ b/WebAssembly/Runtime/StackTooSmallException.cs
@@ -19,6 +19,19 @@
         }
 
         /// <summary>
+        /// Creates a new <see cref="StackTooSmallException"/> with the provided parameters.
+        /// </summary>
+        /// <param name="miscellaneousOpCode">The miscellaneous operation attempted.</param>
+        /// <param name="minimum">The minimum acceptable stack height.</param>
+        /// <param name="actual">The actual stack height at the time the operation was attempted.</param>
+        public StackTooSmallException(MiscellaneousOpCode miscellaneousOpCode, int minimum, int actual)
+            : base(miscellaneousOpCode, $"requires at least {minimum} values on the stack, found {actual}.")
+        {
+            this.Minimum = minimum;
+            this.Actual = actual;
+        }
+
+        /// <summary>
         /// The minimum acceptable stack height.
         /// </summary>
         public int Minimum { get; }

--- a/WebAssembly/Runtime/StackTypeInvalidException.cs
+++ b/WebAssembly/Runtime/StackTypeInvalidException.cs
@@ -19,6 +19,19 @@
         }
 
         /// <summary>
+        /// Creates a new <see cref="StackTypeInvalidException"/> with the provided parameters.
+        /// </summary>
+        /// <param name="miscellaneousOpCode">The miscellaneous operation attempted.</param>
+        /// <param name="expected">The expected value type.</param>
+        /// <param name="actual">The actual value type.</param>
+        public StackTypeInvalidException(MiscellaneousOpCode miscellaneousOpCode, WebAssemblyValueType expected, WebAssemblyValueType actual)
+            : base(miscellaneousOpCode, $"requires the top stack item to be {expected}, found {actual}.")
+        {
+            this.Expected = expected;
+            this.Actual = actual;
+        }
+
+        /// <summary>
         /// The expected value type.
         /// </summary>
         public WebAssemblyValueType Expected { get; }


### PR DESCRIPTION
This PR implements the [non-trapping float-to-int conversion](https://github.com/WebAssembly/spec/blob/master/proposals/nontrapping-float-to-int-conversion/Overview.md) instructions. According to [this page](https://github.com/WebAssembly/proposals/blob/master/finished-proposals.md), this is a "finished proposal".

This PR is a bit more involved than my previous one, and I apologise for the size. It seemed easier to do it all in one go than bit-by-bit though. I had to make a few design choices - if you disagree with any of them, I'm happy to rework the PR.

* These new instructions use a [new prefix byte](https://github.com/WebAssembly/spec/blob/master/proposals/nontrapping-float-to-int-conversion/Overview.md#encoding) intended for "miscellaneous operations", so I've introduced the `MiscellaneousOpCode` enum and propagated it to where it was needed.
* I used helper methods to implement the actual saturating truncation logic, because wasm doesn't match .NET behaviour and I assume we want to maintain wasm semantics:
  * In .NET, for a floating-point conversion to integral type in an unchecked context, out-of-range values result in an unspecified value.
  * In wasm, out-of-range values result in defined values.

The helper methods are all variants of this C# code:

``` csharp
public static int Int32TruncateSaturateFloat32Signed(float f)
{
    if (f >= int.MaxValue)
        return int.MaxValue;

    if (f <= int.MinValue)
        return int.MinValue;

    if (float.IsNaN(f))
        return 0;

    return (int)f;
}
```