### PR TITLE
(WIP) Handle unreachable

### DIFF
--- a/WebAssembly.Tests/Runtime/SpecTestRunner.cs
+++ b/WebAssembly.Tests/Runtime/SpecTestRunner.cs
@@ -324,6 +324,9 @@ namespace WebAssembly.Runtime
                                 case "indirect call type mismatch":
                                     Assert.ThrowsException<InvalidCastException>(trapExpected, $"{command.line}");
                                     continue;
+                                case "unreachable":
+                                    Assert.ThrowsException<UnreachableException>(trapExpected, $"{command.line}");
+                                    continue;
                                 default:
                                     throw new AssertFailedException($"{command.line}: {assert.text} doesn't have a test procedure set up.");
                             }

--- a/WebAssembly.Tests/Runtime/SpecTests.cs
+++ b/WebAssembly.Tests/Runtime/SpecTests.cs
@@ -988,7 +988,6 @@ namespace WebAssembly.Runtime
         /// Runs the unreachable tests.
         /// </summary>
         [TestMethod]
-        [Ignore("StackSizeIncorrectException")]
         public void SpecTest_unreachable()
         {
             SpecTestRunner.Run(Path.Combine("Runtime", "SpecTestData", "unreachable"), "unreachable.json");

--- a/WebAssembly/Instructions/Block.cs
+++ b/WebAssembly/Instructions/Block.cs
@@ -37,6 +37,7 @@ namespace WebAssembly.Instructions
         {
             context.Labels.Add(checked((uint)context.Depth.Count), context.DefineLabel());
             context.Depth.Push(Type);
+            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack));
         }
     }
 }

--- a/WebAssembly/Instructions/Branch.cs
+++ b/WebAssembly/Instructions/Branch.cs
@@ -68,6 +68,9 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             context.Emit(OpCodes.Br, context.Labels[checked((uint)context.Depth.Count) - this.Index - 1]);
+
+            //Mark the following code within this block is unreachable
+            context.BlockContexts[checked((uint)context.Depth.Count)].MarkUnreachable();
         }
     }
 }

--- a/WebAssembly/Instructions/BranchTable.cs
+++ b/WebAssembly/Instructions/BranchTable.cs
@@ -132,6 +132,9 @@ namespace WebAssembly.Instructions
             var blockDepth = checked((uint)context.Depth.Count);
             context.Emit(OpCodes.Switch, this.Labels.Select(index => context.Labels[blockDepth - index - 1]).ToArray());
             context.Emit(OpCodes.Br, context.Labels[blockDepth - this.DefaultLabel - 1]);
+
+            //Mark the following code within this block is unreachable
+            context.BlockContexts[checked((uint)context.Depth.Count)].MarkUnreachable();
         }
     }
 }

--- a/WebAssembly/Instructions/If.cs
+++ b/WebAssembly/Instructions/If.cs
@@ -48,6 +48,7 @@ namespace WebAssembly.Instructions
             var label = context.DefineLabel();
             context.Labels.Add(checked((uint)context.Depth.Count), label);
             context.Depth.Push(Type);
+            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack));
             context.Emit(OpCodes.Brfalse, label);
         }
     }

--- a/WebAssembly/Instructions/Loop.cs
+++ b/WebAssembly/Instructions/Loop.cs
@@ -38,6 +38,7 @@ namespace WebAssembly.Instructions
             var loopStart = context.DefineLabel();
             context.Labels.Add(checked((uint)context.Depth.Count), loopStart);
             context.Depth.Push(Type);
+            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack));
             context.MarkLabel(loopStart);
             context.LoopLabels.Add(loopStart);
         }

--- a/WebAssembly/Instructions/Return.cs
+++ b/WebAssembly/Instructions/Return.cs
@@ -61,6 +61,9 @@ namespace WebAssembly.Instructions
             }
 
             context.Emit(OpCodes.Ret);
+
+            //Mark the following code within this block is unreachable
+            context.BlockContexts[checked((uint)context.Depth.Count)].MarkUnreachable();
         }
     }
 }

--- a/WebAssembly/Instructions/Unreachable.cs
+++ b/WebAssembly/Instructions/Unreachable.cs
@@ -28,6 +28,9 @@ namespace WebAssembly.Instructions
         {
             context.Emit(OpCodes.Newobj, typeof(UnreachableException).GetTypeInfo().DeclaredConstructors.First(c => c.GetParameters().Length == 0));
             context.Emit(OpCodes.Throw);
+
+            //Mark the following code within this block is unreachable
+            context.BlockContexts[checked((uint)context.Depth.Count)].MarkUnreachable();
         }
     }
 }

--- a/WebAssembly/Runtime/Compilation/BlockContext.cs
+++ b/WebAssembly/Runtime/Compilation/BlockContext.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+
+namespace WebAssembly.Runtime.Compilation
+{
+    /// <summary>
+    /// Remembers stack state at the beginning of a block, and reachability of code.
+    /// </summary>
+    internal sealed class BlockContext
+    {
+        public readonly WebAssemblyValueType[] InitialStack;
+        public bool IsUnreachable { get; private set; }
+
+        public BlockContext()
+        {
+            IsUnreachable = false;
+            InitialStack = new WebAssemblyValueType[0];
+        }
+
+        public BlockContext(Stack<WebAssemblyValueType> initialStack)
+        {
+            InitialStack = initialStack.ToArray();  //Copy stack
+            IsUnreachable = false;
+        }
+
+        public void MarkUnreachable()
+        {
+            IsUnreachable = true;
+        }
+
+        public void MarkReachable()
+        {
+            IsUnreachable = false;
+        }
+    }
+}

--- a/WebAssembly/Runtime/Compilation/CompilationContext.cs
+++ b/WebAssembly/Runtime/Compilation/CompilationContext.cs
@@ -58,6 +58,8 @@ namespace WebAssembly.Runtime.Compilation
             this.Labels.Clear();
             this.LoopLabels.Clear();
             this.Stack.Clear();
+            this.BlockContexts.Clear();
+            this.BlockContexts.Add(checked((uint)this.Depth.Count), new BlockContext());
         }
 
         public Signature[]? FunctionSignatures;
@@ -120,6 +122,8 @@ namespace WebAssembly.Runtime.Compilation
         public readonly HashSet<Label> LoopLabels = new HashSet<Label>();
 
         public readonly Stack<WebAssemblyValueType> Stack = new Stack<WebAssemblyValueType>();
+
+        public readonly Dictionary<uint, BlockContext> BlockContexts = new Dictionary<uint, BlockContext>();
 
         public WebAssemblyValueType[] CheckedLocals => Locals ?? throw new InvalidOperationException();
 


### PR DESCRIPTION
This PR allows compilation of some WASM codes which previously generated compilation error.
In particular, it solves some `unreachable`-related problems, such as:
  - Issue #21 (GreenGood's `wasm.zip` successfully compiles, aside from lacking imports)
  - `SpecTest_unreachable` (removed `[Ignore(StackSizeIncorrectException)]` and passes this spec test).

What I did was:
  - Stopped ignoring `StackSizeException` in `SpecTest_unreachable`.
  - Created `BlockContext` mechanism inside `CompilationContext`, to remember stack at the beginning of a block and whether the compiling instruction is reachable.
  - Skip compilation (including type check) of unreachable instructions.

However, at present, some invalid WASM code involving `unreachable` (in `SpecTest_unreached_invalid`) passes compilation, because all unreachable code is now ignored.
Therefore, this PR is currently marked Draft.

(Update)
- Skip unreachable instructions following `return`, `br`, `br_table`. (Sorry, commit message of 62d5fd8 is mistake)
  - It allows more WASM codes to compile, but some SpecTests are failing because invalid codes are not detected.