### PR TITLE
Handle unreachable

### DIFF
--- a/WebAssembly.Tests/Runtime/SpecTestRunner.cs
+++ b/WebAssembly.Tests/Runtime/SpecTestRunner.cs
@@ -324,6 +324,9 @@ namespace WebAssembly.Runtime
                                 case "indirect call type mismatch":
                                     Assert.ThrowsException<InvalidCastException>(trapExpected, $"{command.line}");
                                     continue;
+                                case "unreachable":
+                                    Assert.ThrowsException<UnreachableException>(trapExpected, $"{command.line}");
+                                    continue;
                                 default:
                                     throw new AssertFailedException($"{command.line}: {assert.text} doesn't have a test procedure set up.");
                             }

--- a/WebAssembly.Tests/Runtime/SpecTestRunner.cs
+++ b/WebAssembly.Tests/Runtime/SpecTestRunner.cs
@@ -215,6 +215,10 @@ namespace WebAssembly.Runtime
                                     {
                                         continue;
                                     }
+                                    catch (LabelTypeMismatchException)
+                                    {
+                                        continue;
+                                    }
                                     catch (Exception x)
                                     {
                                         throw new AssertFailedException($"{command.line} threw an unexpected exception of type {x.GetType().Name}.");

--- a/WebAssembly.Tests/Runtime/SpecTests.cs
+++ b/WebAssembly.Tests/Runtime/SpecTests.cs
@@ -988,7 +988,6 @@ namespace WebAssembly.Runtime
         /// Runs the unreachable tests.
         /// </summary>
         [TestMethod]
-        [Ignore("StackSizeIncorrectException")]
         public void SpecTest_unreachable()
         {
             SpecTestRunner.Run(Path.Combine("Runtime", "SpecTestData", "unreachable"), "unreachable.json");

--- a/WebAssembly.Tests/Runtime/SpecTests.cs
+++ b/WebAssembly.Tests/Runtime/SpecTests.cs
@@ -878,7 +878,6 @@ namespace WebAssembly.Runtime
         /// Runs the return tests.
         /// </summary>
         [TestMethod]
-        [Ignore("StackTooSmallException")]
         public void SpecTest_return()
         {
             SpecTestRunner.Run(Path.Combine("Runtime", "SpecTestData", "return"), "return.json");
@@ -888,7 +887,6 @@ namespace WebAssembly.Runtime
         /// Runs the select tests.
         /// </summary>
         [TestMethod]
-        [Ignore("StackTooSmallException")]
         public void SpecTest_select()
         {
             SpecTestRunner.Run(Path.Combine("Runtime", "SpecTestData", "select"), "select.json");

--- a/WebAssembly/Instructions/Block.cs
+++ b/WebAssembly/Instructions/Block.cs
@@ -37,6 +37,7 @@ namespace WebAssembly.Instructions
         {
             context.Labels.Add(checked((uint)context.Depth.Count), context.DefineLabel());
             context.Depth.Push(Type);
+            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack));
         }
     }
 }

--- a/WebAssembly/Instructions/Block.cs
+++ b/WebAssembly/Instructions/Block.cs
@@ -37,7 +37,7 @@ namespace WebAssembly.Instructions
         {
             context.Labels.Add(checked((uint)context.Depth.Count), context.DefineLabel());
             context.Depth.Push(Type);
-            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack));
+            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack.Count));
         }
     }
 }

--- a/WebAssembly/Instructions/Branch.cs
+++ b/WebAssembly/Instructions/Branch.cs
@@ -74,8 +74,8 @@ namespace WebAssembly.Instructions
 
             context.Emit(OpCodes.Br, context.Labels[checked((uint)context.Depth.Count) - this.Index - 1]);
 
-            //Mark the following code within this block is unreachable
-            context.BlockContexts[checked((uint)context.Depth.Count)].MarkUnreachable();
+            //Mark the subsequent code within this block is unreachable
+            context.MarkUnreachable();
         }
     }
 }

--- a/WebAssembly/Instructions/Branch.cs
+++ b/WebAssembly/Instructions/Branch.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection.Emit;
 using WebAssembly.Runtime.Compilation;
 
@@ -67,7 +68,14 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
+            var blockType = context.Depth.ElementAt(checked((int)this.Index));
+            if (blockType.TryToValueType(out var expectedType))
+                context.PeekStack(this.OpCode, expectedType);
+
             context.Emit(OpCodes.Br, context.Labels[checked((uint)context.Depth.Count) - this.Index - 1]);
+
+            //Mark the following code within this block is unreachable
+            context.BlockContexts[checked((uint)context.Depth.Count)].MarkUnreachable();
         }
     }
 }

--- a/WebAssembly/Instructions/BranchIf.cs
+++ b/WebAssembly/Instructions/BranchIf.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection.Emit;
 using WebAssembly.Runtime;
 using WebAssembly.Runtime.Compilation;
@@ -68,13 +69,11 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.If, 1, 0);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int32);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.If, WebAssemblyValueType.Int32, type);
+            var blockType = context.Depth.ElementAt(checked((int)this.Index));
+            if (blockType.TryToValueType(out var expectedType))
+                context.PeekStack(this.OpCode, expectedType);
 
             context.Emit(OpCodes.Brtrue, context.Labels[checked((uint)context.Depth.Count) - this.Index - 1]);
         }

--- a/WebAssembly/Instructions/BranchTable.cs
+++ b/WebAssembly/Instructions/BranchTable.cs
@@ -139,7 +139,7 @@ namespace WebAssembly.Instructions
             context.Emit(OpCodes.Switch, this.Labels.Select(index => context.Labels[blockDepth - index - 1]).ToArray());
             context.Emit(OpCodes.Br, context.Labels[blockDepth - this.DefaultLabel - 1]);
 
-            //Mark the following code within this block is unreachable
+            //Mark the subsequent code within this block is unreachable
             context.MarkUnreachable();
         }
     }

--- a/WebAssembly/Instructions/BranchTable.cs
+++ b/WebAssembly/Instructions/BranchTable.cs
@@ -123,15 +123,16 @@ namespace WebAssembly.Instructions
         {
             context.PopStack(OpCode.BranchTable, WebAssemblyValueType.Int32);
 
-            var blockType = context.Depth.ElementAt(checked((int)this.DefaultLabel));
-            if (blockType.TryToValueType(out var expectedType))
+            var defaultLabelType = context.Depth.ElementAt(checked((int)this.DefaultLabel));
+            if (defaultLabelType.TryToValueType(out var expectedType))
                 context.PeekStack(this.OpCode, expectedType);
 
             //All target labels should have the same type
             foreach (var label in this.Labels)
             {
-                if (context.Depth.ElementAt(checked((int)label)) != blockType)
-                    throw new OpCodeCompilationException(this.OpCode, "All target should have the same type.");
+                var labelType = context.Depth.ElementAt(checked((int)label));
+                if (labelType != defaultLabelType)
+                    throw new LabelTypeMismatchException(this.OpCode, defaultLabelType, labelType);
             }
 
             var blockDepth = checked((uint)context.Depth.Count);

--- a/WebAssembly/Instructions/BranchTable.cs
+++ b/WebAssembly/Instructions/BranchTable.cs
@@ -121,17 +121,25 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.BranchTable, 1, 0);
+            context.PopStack(OpCode.BranchTable, WebAssemblyValueType.Int32);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.BranchTable, WebAssemblyValueType.Int32, type);
+            var blockType = context.Depth.ElementAt(checked((int)this.DefaultLabel));
+            if (blockType.TryToValueType(out var expectedType))
+                context.PeekStack(this.OpCode, expectedType);
+
+            //All target labels should have the same type
+            foreach (var label in this.Labels)
+            {
+                if (context.Depth.ElementAt(checked((int)label)) != blockType)
+                    throw new OpCodeCompilationException(this.OpCode, "All target should have the same type.");
+            }
 
             var blockDepth = checked((uint)context.Depth.Count);
             context.Emit(OpCodes.Switch, this.Labels.Select(index => context.Labels[blockDepth - index - 1]).ToArray());
             context.Emit(OpCodes.Br, context.Labels[blockDepth - this.DefaultLabel - 1]);
+
+            //Mark the following code within this block is unreachable
+            context.MarkUnreachable();
         }
     }
 }

--- a/WebAssembly/Instructions/Call.cs
+++ b/WebAssembly/Instructions/Call.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection.Emit;
 using WebAssembly.Runtime;
 using WebAssembly.Runtime.Compilation;
@@ -86,15 +87,8 @@ namespace WebAssembly.Instructions
             var returnTypes = signature.RawReturnTypes;
 
             var stack = context.Stack;
-            if (stack.Count < paramTypes.Length)
-                throw new StackTooSmallException(this.OpCode, paramTypes.Length, stack.Count);
 
-            for (var i = paramTypes.Length - 1; i >= 0; i--)
-            {
-                var type = stack.Pop();
-                if (type != paramTypes[i])
-                    throw new StackTypeInvalidException(this.OpCode, paramTypes[i], type);
-            }
+            context.PopStack(this.OpCode, paramTypes.Cast<WebAssemblyValueType?>().Reverse().ToArray());
 
             for (var i = 0; i < returnTypes.Length; i++)
                 stack.Push(returnTypes[i]);

--- a/WebAssembly/Instructions/CallIndirect.cs
+++ b/WebAssembly/Instructions/CallIndirect.cs
@@ -90,19 +90,8 @@ namespace WebAssembly.Instructions
             var returnTypes = signature.RawReturnTypes;
 
             var stack = context.Stack;
-            if (stack.Count < paramTypes.Length + 1)
-                throw new StackTooSmallException(OpCode.CallIndirect, paramTypes.Length + 1, stack.Count);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.CallIndirect, WebAssemblyValueType.Int32, type);
-
-            for (var i = paramTypes.Length - 1; i >= 0; i--)
-            {
-                type = stack.Pop();
-                if (type != paramTypes[i])
-                    throw new StackTypeInvalidException(OpCode.CallIndirect, paramTypes[i], type);
-            }
+            context.PopStack(OpCode.CallIndirect, paramTypes.Cast<WebAssemblyValueType?>().Reverse().Prepend(WebAssemblyValueType.Int32).ToArray());
 
             for (var i = 0; i < returnTypes.Length; i++)
                 stack.Push(returnTypes[i]);

--- a/WebAssembly/Instructions/Drop.cs
+++ b/WebAssembly/Instructions/Drop.cs
@@ -23,11 +23,7 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Drop, 1, 0);
-
-            stack.Pop();
+            context.PopStack(OpCode.Drop, new WebAssemblyValueType?[] { null });
 
             context.Emit(OpCodes.Pop);
         }

--- a/WebAssembly/Instructions/Else.cs
+++ b/WebAssembly/Instructions/Else.cs
@@ -27,9 +27,7 @@ namespace WebAssembly.Instructions
 
             if (blockType.TryToValueType(out var expectedType))
             {
-                var type = context.Stack.Pop();
-                if (type != expectedType)
-                    throw new StackTypeInvalidException(OpCode.Else, expectedType, type);
+                context.PopStack(OpCode.Else, expectedType);
             }
 
             var afterElse = context.DefineLabel();
@@ -38,6 +36,9 @@ namespace WebAssembly.Instructions
             var target = checked((uint)context.Depth.Count) - 1;
             context.MarkLabel(context.Labels[target]);
             context.Labels[target] = afterElse;
+
+            //Else-block is reachable even if the then-block is unreachable
+            context.MarkReachable();
         }
     }
 }

--- a/WebAssembly/Instructions/End.cs
+++ b/WebAssembly/Instructions/End.cs
@@ -36,7 +36,7 @@ namespace WebAssembly.Instructions
 
                 var returns = context.CheckedSignature.RawReturnTypes;
                 var returnsLength = returns.Length;
-                if (returnsLength < stack.Count || (returnsLength > stack.Count && !blockContext.IsUnreachable))
+                if (returnsLength < stack.Count || (returnsLength > stack.Count && !context.IsUnreachable()))
                     throw new StackSizeIncorrectException(OpCode.End, returnsLength, stack.Count);
 
                 Assert(returnsLength == 0 || returnsLength == 1); //WebAssembly doesn't currently offer multiple returns, which should be blocked earlier.
@@ -58,7 +58,6 @@ namespace WebAssembly.Instructions
                     if (!peeked[0].HasValue)
                         throw new OpCodeCompilationException(OpCode.End, "Cannot determine stack type.");
                 }
-
 
                 context.BlockContexts.Remove(checked((uint)context.Depth.Count));
                 context.Depth.Pop();

--- a/WebAssembly/Instructions/End.cs
+++ b/WebAssembly/Instructions/End.cs
@@ -26,25 +26,26 @@ namespace WebAssembly.Instructions
         {
             var stack = context.Stack;
 
-            var blockType = context.Depth.Count == 0 ? BlockType.Empty : context.Depth.Pop();
+            var blockContext = context.BlockContexts[checked((uint)context.Depth.Count)];
+            var blockType = context.Depth.Count == 0 ? BlockType.Empty : context.Depth.Peek();
 
-            if (context.Depth.Count == 0)
+            if (context.Depth.Count == 1)
             {
                 if (context.Previous == OpCode.Return)
                     return; //WebAssembly requires functions to end on "end", but an immediately previous return is allowed.
 
                 var returns = context.CheckedSignature.RawReturnTypes;
                 var returnsLength = returns.Length;
-                if (returnsLength != stack.Count)
+                if (returnsLength < stack.Count || (returnsLength > stack.Count && !blockContext.IsUnreachable))
                     throw new StackSizeIncorrectException(OpCode.End, returnsLength, stack.Count);
 
                 Assert(returnsLength == 0 || returnsLength == 1); //WebAssembly doesn't currently offer multiple returns, which should be blocked earlier.
 
                 if (returnsLength == 1)
                 {
-                    var type = stack.Pop();
-                    if (type != returns[0])
-                        throw new StackTypeInvalidException(OpCode.End, returns[0], type);
+                    var popped = context.PopStack(OpCode.End, returns[0]);
+                    if (!popped[0].HasValue)
+                        throw new OpCodeCompilationException(OpCode.End, "Cannot determine stack type.");
                 }
 
                 context.Emit(OpCodes.Ret);
@@ -53,10 +54,14 @@ namespace WebAssembly.Instructions
             {
                 if (blockType.TryToValueType(out var expectedType))
                 {
-                    var type = stack.Peek();
-                    if (type != expectedType)
-                        throw new StackTypeInvalidException(OpCode.End, expectedType, type);
+                    var peeked = context.PeekStack(OpCode.End, expectedType);
+                    if (!peeked[0].HasValue)
+                        throw new OpCodeCompilationException(OpCode.End, "Cannot determine stack type.");
                 }
+
+
+                context.BlockContexts.Remove(checked((uint)context.Depth.Count));
+                context.Depth.Pop();
 
                 var depth = checked((uint)context.Depth.Count);
                 var label = context.Labels[depth];

--- a/WebAssembly/Instructions/Float32ConvertInt32Signed.cs
+++ b/WebAssembly/Instructions/Float32ConvertInt32Signed.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float32ConvertInt32Signed, 1, 0);
-
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Float32ConvertInt32Signed, WebAssemblyValueType.Int32, type);
+            
+            context.PopStack(OpCode.Float32ConvertInt32Signed, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Conv_R4);
 

--- a/WebAssembly/Instructions/Float32ConvertInt32Unsigned.cs
+++ b/WebAssembly/Instructions/Float32ConvertInt32Unsigned.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float32ConvertInt32Unsigned, 1, 0);
-
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Float32ConvertInt32Unsigned, WebAssemblyValueType.Int32, type);
+            
+            context.PopStack(OpCode.Float32ConvertInt32Unsigned, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Conv_R_Un);
             context.Emit(OpCodes.Conv_R4);

--- a/WebAssembly/Instructions/Float32ConvertInt64Signed.cs
+++ b/WebAssembly/Instructions/Float32ConvertInt64Signed.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float32ConvertInt64Signed, 1, 0);
-
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Float32ConvertInt64Signed, WebAssemblyValueType.Int64, type);
+            
+            context.PopStack(OpCode.Float32ConvertInt64Signed, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Conv_R4);
 

--- a/WebAssembly/Instructions/Float32ConvertInt64Unsigned.cs
+++ b/WebAssembly/Instructions/Float32ConvertInt64Unsigned.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float32ConvertInt64Unsigned, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Float32ConvertInt64Unsigned, WebAssemblyValueType.Int64, type);
+            context.PopStack(OpCode.Float32ConvertInt64Unsigned, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Conv_R_Un);
             context.Emit(OpCodes.Conv_R4);

--- a/WebAssembly/Instructions/Float32CopySign.cs
+++ b/WebAssembly/Instructions/Float32CopySign.cs
@@ -23,17 +23,7 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Float32CopySign, 1, stack.Count);
-
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(OpCode.Float32CopySign, WebAssemblyValueType.Float32, type);
-
-            type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(OpCode.Float32CopySign, WebAssemblyValueType.Float32, type);
+            context.PopStack(OpCode.Float32CopySign, WebAssemblyValueType.Float32, WebAssemblyValueType.Float32);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Float32CopySign, (helper, c) =>
             {
@@ -68,6 +58,8 @@ namespace WebAssembly.Instructions
                 return builder;
             }
             ]);
+
+            context.Stack.Push(WebAssemblyValueType.Float32);
         }
     }
 }

--- a/WebAssembly/Instructions/Float32DemoteFloat64.cs
+++ b/WebAssembly/Instructions/Float32DemoteFloat64.cs
@@ -23,17 +23,10 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float32DemoteFloat64, 1, 0);
-
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float64)
-                throw new StackTypeInvalidException(OpCode.Float32DemoteFloat64, WebAssemblyValueType.Float64, type);
+            context.PopStack(OpCode.Float32DemoteFloat64, WebAssemblyValueType.Float64);
+            context.Stack.Push(WebAssemblyValueType.Float32);
 
             context.Emit(OpCodes.Conv_R4);
-
-            stack.Push(WebAssemblyValueType.Float32);
         }
     }
 }

--- a/WebAssembly/Instructions/Float32ReinterpretInt32.cs
+++ b/WebAssembly/Instructions/Float32ReinterpretInt32.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Float32ReinterpretInt32, 1, stack.Count);
-
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Float32ReinterpretInt32, WebAssemblyValueType.Int32, type);
+            
+            context.PopStack(OpCode.Float32ReinterpretInt32, WebAssemblyValueType.Int32);
 
             stack.Push(WebAssemblyValueType.Float32);
 

--- a/WebAssembly/Instructions/Float64CallWrapperInstruction.cs
+++ b/WebAssembly/Instructions/Float64CallWrapperInstruction.cs
@@ -18,13 +18,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(this.OpCode, 1, 0);
-
-            var type = stack.Peek();  //Assuming validation passes, the remaining type will be this.
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Float32, type);
+            //Assuming validation passes, the remaining type will be Float32.
+            context.PeekStack(this.OpCode, WebAssemblyValueType.Float32);
 
             context.Emit(OpCodes.Conv_R8);
             context.Emit(OpCodes.Call, this.MethodInfo);

--- a/WebAssembly/Instructions/Float64ConvertInt32Signed.cs
+++ b/WebAssembly/Instructions/Float64ConvertInt32Signed.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float64ConvertInt32Signed, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Float64ConvertInt32Signed, WebAssemblyValueType.Int32, type);
+            context.PopStack(OpCode.Float64ConvertInt32Signed, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Conv_R8);
 

--- a/WebAssembly/Instructions/Float64ConvertInt32Unsigned.cs
+++ b/WebAssembly/Instructions/Float64ConvertInt32Unsigned.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float64ConvertInt32Unsigned, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Float64ConvertInt32Unsigned, WebAssemblyValueType.Int32, type);
+            context.PopStack(OpCode.Float64ConvertInt32Unsigned, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Conv_R_Un);
             context.Emit(OpCodes.Conv_R8);

--- a/WebAssembly/Instructions/Float64ConvertInt64Signed.cs
+++ b/WebAssembly/Instructions/Float64ConvertInt64Signed.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float64ConvertInt64Signed, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Float64ConvertInt64Signed, WebAssemblyValueType.Int64, type);
+            context.PopStack(OpCode.Float64ConvertInt64Signed, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Conv_R8);
 

--- a/WebAssembly/Instructions/Float64ConvertInt64Unsigned.cs
+++ b/WebAssembly/Instructions/Float64ConvertInt64Unsigned.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float64ConvertInt64Unsigned, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Float64ConvertInt64Unsigned, WebAssemblyValueType.Int64, type);
+            context.PopStack(OpCode.Float64ConvertInt64Unsigned, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Conv_R_Un);
             context.Emit(OpCodes.Conv_R8);

--- a/WebAssembly/Instructions/Float64CopySign.cs
+++ b/WebAssembly/Instructions/Float64CopySign.cs
@@ -23,17 +23,7 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Float64CopySign, 1, stack.Count);
-
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float64)
-                throw new StackTypeInvalidException(OpCode.Float64CopySign, WebAssemblyValueType.Float64, type);
-
-            type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-            if (type != WebAssemblyValueType.Float64)
-                throw new StackTypeInvalidException(OpCode.Float64CopySign, WebAssemblyValueType.Float64, type);
+            context.PopStack(OpCode.Float64CopySign, WebAssemblyValueType.Float64, WebAssemblyValueType.Float64);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Float64CopySign, (helper, c) =>
             {
@@ -68,6 +58,8 @@ namespace WebAssembly.Instructions
                 return builder;
             }
             ]);
+
+            context.Stack.Push(WebAssemblyValueType.Float64);
         }
     }
 }

--- a/WebAssembly/Instructions/Float64PromoteFloat32.cs
+++ b/WebAssembly/Instructions/Float64PromoteFloat32.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Float64PromoteFloat32, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(OpCode.Float64PromoteFloat32, WebAssemblyValueType.Float32, type);
+            context.PopStack(OpCode.Float64PromoteFloat32, WebAssemblyValueType.Float32);
 
             context.Emit(OpCodes.Conv_R8);
 

--- a/WebAssembly/Instructions/Float64ReinterpretInt64.cs
+++ b/WebAssembly/Instructions/Float64ReinterpretInt64.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Float64ReinterpretInt64, 1, stack.Count);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Float64ReinterpretInt64, WebAssemblyValueType.Int64, type);
+            context.PopStack(OpCode.Float64ReinterpretInt64, WebAssemblyValueType.Int64);
 
             stack.Push(WebAssemblyValueType.Float64);
 

--- a/WebAssembly/Instructions/GlobalSet.cs
+++ b/WebAssembly/Instructions/GlobalSet.cs
@@ -40,10 +40,6 @@ namespace WebAssembly.Instructions
             if (context.Globals == null)
                 throw new CompilerException("Can't use SetGlobal without a global section or global imports.");
 
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.GlobalSet, 1, stack.Count);
-
             GlobalInfo global;
             try
             {
@@ -57,9 +53,7 @@ namespace WebAssembly.Instructions
             if (global.Setter == null)
                 throw new CompilerException($"Global at index {this.Index} is immutable.");
 
-            var type = stack.Pop();
-            if (type != global.Type)
-                throw new StackTypeInvalidException(OpCode.GlobalSet, global.Type, type);
+            context.PopStack(OpCode.GlobalSet, global.Type);
 
             if (global.RequiresInstance)
                 context.EmitLoadThis();

--- a/WebAssembly/Instructions/If.cs
+++ b/WebAssembly/Instructions/If.cs
@@ -37,17 +37,12 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.If, 1, 0);
-
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.If, WebAssemblyValueType.Int32, type);
+            context.PopStack(OpCode.If, WebAssemblyValueType.Int32);
 
             var label = context.DefineLabel();
             context.Labels.Add(checked((uint)context.Depth.Count), label);
             context.Depth.Push(Type);
+            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack));
             context.Emit(OpCodes.Brfalse, label);
         }
     }

--- a/WebAssembly/Instructions/If.cs
+++ b/WebAssembly/Instructions/If.cs
@@ -42,7 +42,7 @@ namespace WebAssembly.Instructions
             var label = context.DefineLabel();
             context.Labels.Add(checked((uint)context.Depth.Count), label);
             context.Depth.Push(Type);
-            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack));
+            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack.Count));
             context.Emit(OpCodes.Brfalse, label);
         }
     }

--- a/WebAssembly/Instructions/Int32CountLeadingZeroes.cs
+++ b/WebAssembly/Instructions/Int32CountLeadingZeroes.cs
@@ -23,14 +23,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Int32CountLeadingZeroes, 1, stack.Count);
-
-            var type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Int32CountLeadingZeroes, WebAssemblyValueType.Int32, type);
+            //Assuming validation passes, the remaining type will be Int32.
+            context.PeekStack(OpCode.Int32CountLeadingZeroes, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int32CountLeadingZeroes, (helper, c) =>
             {

--- a/WebAssembly/Instructions/Int32CountOneBits.cs
+++ b/WebAssembly/Instructions/Int32CountOneBits.cs
@@ -23,14 +23,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Int32CountOneBits, 1, stack.Count);
-
-            var type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Int32CountOneBits, WebAssemblyValueType.Int32, type);
+            //Assuming validation passes, the remaining type will be Int32.
+            context.PeekStack(OpCode.Int32CountOneBits, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int32CountOneBits, CreateHelper]);
         }

--- a/WebAssembly/Instructions/Int32CountTrailingZeroes.cs
+++ b/WebAssembly/Instructions/Int32CountTrailingZeroes.cs
@@ -23,14 +23,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Int32CountTrailingZeroes, 1, stack.Count);
-
-            var type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Int32CountTrailingZeroes, WebAssemblyValueType.Int32, type);
+            //Assuming validation passes, the remaining type will be this.
+            context.PeekStack(OpCode.Int32CountTrailingZeroes, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int32CountTrailingZeroes, (helper, c) =>
             {

--- a/WebAssembly/Instructions/Int32EqualZero.cs
+++ b/WebAssembly/Instructions/Int32EqualZero.cs
@@ -23,14 +23,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
-
-            var type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int32, type);
+            //Assuming validation passes, the remaining type will be Int32.
+            context.PeekStack(this.OpCode, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Ldc_I4_0);
             context.Emit(OpCodes.Ceq);

--- a/WebAssembly/Instructions/Int32Extend16Signed.cs
+++ b/WebAssembly/Instructions/Int32Extend16Signed.cs
@@ -24,13 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
 
-            var type = stack.Pop();
-
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int32, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Conv_I2);
             context.Emit(OpCodes.Conv_I4);

--- a/WebAssembly/Instructions/Int32Extend8Signed.cs
+++ b/WebAssembly/Instructions/Int32Extend8Signed.cs
@@ -24,13 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
 
-            var type = stack.Pop();
-
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int32, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Conv_I1);
             context.Emit(OpCodes.Conv_I4);

--- a/WebAssembly/Instructions/Int32ReinterpretFloat32.cs
+++ b/WebAssembly/Instructions/Int32ReinterpretFloat32.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Int32ReinterpretFloat32, 1, stack.Count);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(OpCode.Int32ReinterpretFloat32, WebAssemblyValueType.Float32, type);
+            context.PopStack(OpCode.Int32ReinterpretFloat32, WebAssemblyValueType.Float32);
 
             stack.Push(WebAssemblyValueType.Int32);
 

--- a/WebAssembly/Instructions/Int32RotateLeft.cs
+++ b/WebAssembly/Instructions/Int32RotateLeft.cs
@@ -24,17 +24,9 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 2)
-                throw new StackTooSmallException(OpCode.Int32RotateLeft, 2, stack.Count);
 
-            var typeB = stack.Pop();
-            var typeA = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (typeA != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Int32RotateLeft, WebAssemblyValueType.Int32, typeA);
-
-            if (typeA != typeB)
-                throw new StackParameterMismatchException(OpCode.Int32RotateLeft, typeA, typeB);
+            context.PopStack(OpCode.Int32RotateLeft, WebAssemblyValueType.Int32, WebAssemblyValueType.Int32);
+            stack.Push(WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int32RotateLeft, (helper, c) =>
             {

--- a/WebAssembly/Instructions/Int32RotateRight.cs
+++ b/WebAssembly/Instructions/Int32RotateRight.cs
@@ -24,17 +24,9 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 2)
-                throw new StackTooSmallException(OpCode.Int32RotateRight, 2, stack.Count);
 
-            var typeB = stack.Pop();
-            var typeA = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (typeA != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Int32RotateRight, WebAssemblyValueType.Int32, typeA);
-
-            if (typeA != typeB)
-                throw new StackParameterMismatchException(OpCode.Int32RotateRight, typeA, typeB);
+            context.PopStack(OpCode.Int32RotateRight, WebAssemblyValueType.Int32, WebAssemblyValueType.Int32);
+            stack.Push(WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int32RotateRight, (helper, c) =>
             {

--- a/WebAssembly/Instructions/Int32TruncateFloat32Signed.cs
+++ b/WebAssembly/Instructions/Int32TruncateFloat32Signed.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Int32TruncateFloat32Signed, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(OpCode.Int32TruncateFloat32Signed, WebAssemblyValueType.Float32, type);
+            context.PopStack(OpCode.Int32TruncateFloat32Signed, WebAssemblyValueType.Float32);
 
             context.Emit(OpCodes.Conv_Ovf_I4);
 

--- a/WebAssembly/Instructions/Int32TruncateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateFloat32Unsigned.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Int32TruncateFloat32Unsigned, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(OpCode.Int32TruncateFloat32Unsigned, WebAssemblyValueType.Float32, type);
+            context.PopStack(OpCode.Int32TruncateFloat32Unsigned, WebAssemblyValueType.Float32);
 
             context.Emit(OpCodes.Conv_Ovf_I4_Un);
 

--- a/WebAssembly/Instructions/Int32TruncateFloat64Signed.cs
+++ b/WebAssembly/Instructions/Int32TruncateFloat64Signed.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Int32TruncateFloat64Signed, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float64)
-                throw new StackTypeInvalidException(OpCode.Int32TruncateFloat64Signed, WebAssemblyValueType.Float64, type);
+            context.PopStack(OpCode.Int32TruncateFloat64Signed, WebAssemblyValueType.Float64);
 
             context.Emit(OpCodes.Conv_Ovf_I4);
 

--- a/WebAssembly/Instructions/Int32TruncateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateFloat64Unsigned.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Int32TruncateFloat64Unsigned, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float64)
-                throw new StackTypeInvalidException(OpCode.Int32TruncateFloat64Unsigned, WebAssemblyValueType.Float64, type);
+            context.PopStack(OpCode.Int32TruncateFloat64Unsigned, WebAssemblyValueType.Float64);
 
             context.Emit(OpCodes.Conv_Ovf_I4_Un);
 

--- a/WebAssembly/Instructions/Int32WrapInt64.cs
+++ b/WebAssembly/Instructions/Int32WrapInt64.cs
@@ -24,13 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
 
-            var type = stack.Pop();
-
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int64, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Conv_I4);
 

--- a/WebAssembly/Instructions/Int64CountLeadingZeroes.cs
+++ b/WebAssembly/Instructions/Int64CountLeadingZeroes.cs
@@ -23,14 +23,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Int64CountLeadingZeroes, 1, stack.Count);
-
-            var type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Int64CountLeadingZeroes, WebAssemblyValueType.Int64, type);
+            //Assuming validation passes, the remaining type will be Int64.
+            context.PeekStack(OpCode.Int64CountLeadingZeroes, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int64CountLeadingZeroes, (helper, c) =>
             {

--- a/WebAssembly/Instructions/Int64CountOneBits.cs
+++ b/WebAssembly/Instructions/Int64CountOneBits.cs
@@ -23,14 +23,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Int64CountOneBits, 1, stack.Count);
-
-            var type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Int64CountOneBits, WebAssemblyValueType.Int64, type);
+            //Assuming validation passes, the remaining type will be Int64.
+            context.PeekStack(OpCode.Int64CountOneBits, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int64CountOneBits, CreateHelper]);
         }

--- a/WebAssembly/Instructions/Int64CountTrailingZeroes.cs
+++ b/WebAssembly/Instructions/Int64CountTrailingZeroes.cs
@@ -23,14 +23,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Int64CountTrailingZeroes, 1, stack.Count);
-
-            var type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Int64CountTrailingZeroes, WebAssemblyValueType.Int64, type);
+            //Assuming validation passes, the remaining type will be Int64.
+            context.PeekStack(OpCode.Int64CountTrailingZeroes, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int64CountTrailingZeroes, (helper, c) =>
             {

--- a/WebAssembly/Instructions/Int64EqualZero.cs
+++ b/WebAssembly/Instructions/Int64EqualZero.cs
@@ -24,13 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
 
-            var type = stack.Pop();
-
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int64, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int64);
 
             stack.Push(WebAssemblyValueType.Int32);
 

--- a/WebAssembly/Instructions/Int64Extend16Signed.cs
+++ b/WebAssembly/Instructions/Int64Extend16Signed.cs
@@ -24,13 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
 
-            var type = stack.Pop();
-
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int64, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Conv_I2);
             context.Emit(OpCodes.Conv_I8);

--- a/WebAssembly/Instructions/Int64Extend32Signed.cs
+++ b/WebAssembly/Instructions/Int64Extend32Signed.cs
@@ -24,13 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
 
-            var type = stack.Pop();
-
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int64, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Conv_I4);
             context.Emit(OpCodes.Conv_I8);

--- a/WebAssembly/Instructions/Int64Extend8Signed.cs
+++ b/WebAssembly/Instructions/Int64Extend8Signed.cs
@@ -24,13 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
 
-            var type = stack.Pop();
-
-            if (type != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int64, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Conv_I1);
             context.Emit(OpCodes.Conv_I8);

--- a/WebAssembly/Instructions/Int64ExtendInt32Signed.cs
+++ b/WebAssembly/Instructions/Int64ExtendInt32Signed.cs
@@ -24,13 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
 
-            var type = stack.Pop();
-
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int32, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Conv_I8);
 

--- a/WebAssembly/Instructions/Int64ExtendInt32Unsigned.cs
+++ b/WebAssembly/Instructions/Int64ExtendInt32Unsigned.cs
@@ -24,13 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
 
-            var type = stack.Pop();
-
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int32, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int32);
 
             context.Emit(OpCodes.Conv_U8);
 

--- a/WebAssembly/Instructions/Int64ReinterpretFloat64.cs
+++ b/WebAssembly/Instructions/Int64ReinterpretFloat64.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.Int64ReinterpretFloat64, 1, stack.Count);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float64)
-                throw new StackTypeInvalidException(OpCode.Int64ReinterpretFloat64, WebAssemblyValueType.Float64, type);
+            context.PopStack(OpCode.Int64ReinterpretFloat64, WebAssemblyValueType.Float64);
 
             stack.Push(WebAssemblyValueType.Int64);
 

--- a/WebAssembly/Instructions/Int64RotateLeft.cs
+++ b/WebAssembly/Instructions/Int64RotateLeft.cs
@@ -24,17 +24,9 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 2)
-                throw new StackTooSmallException(OpCode.Int64RotateLeft, 2, stack.Count);
 
-            var typeB = stack.Pop();
-            var typeA = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (typeA != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Int64RotateLeft, WebAssemblyValueType.Int64, typeA);
-
-            if (typeA != typeB)
-                throw new StackParameterMismatchException(OpCode.Int64RotateLeft, typeA, typeB);
+            context.PopStack(OpCode.Int64RotateLeft, WebAssemblyValueType.Int64, WebAssemblyValueType.Int64);
+            stack.Push(WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int64RotateLeft, (helper, c) =>
             {

--- a/WebAssembly/Instructions/Int64RotateRight.cs
+++ b/WebAssembly/Instructions/Int64RotateRight.cs
@@ -24,17 +24,9 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 2)
-                throw new StackTooSmallException(OpCode.Int64RotateRight, 2, stack.Count);
 
-            var typeB = stack.Pop();
-            var typeA = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (typeA != WebAssemblyValueType.Int64)
-                throw new StackTypeInvalidException(OpCode.Int64RotateRight, WebAssemblyValueType.Int64, typeA);
-
-            if (typeA != typeB)
-                throw new StackParameterMismatchException(OpCode.Int64RotateRight, typeA, typeB);
+            context.PopStack(OpCode.Int64RotateRight, WebAssemblyValueType.Int64, WebAssemblyValueType.Int64);
+            stack.Push(WebAssemblyValueType.Int64);
 
             context.Emit(OpCodes.Call, context[HelperMethod.Int64RotateRight, (helper, c) =>
             {

--- a/WebAssembly/Instructions/Int64TruncateFloat32Signed.cs
+++ b/WebAssembly/Instructions/Int64TruncateFloat32Signed.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Int64TruncateFloat32Signed, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(OpCode.Int64TruncateFloat32Signed, WebAssemblyValueType.Float32, type);
+            context.PopStack(OpCode.Int64TruncateFloat32Signed, WebAssemblyValueType.Float32);
 
             context.Emit(OpCodes.Conv_Ovf_I8);
 

--- a/WebAssembly/Instructions/Int64TruncateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateFloat32Unsigned.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Int64TruncateFloat32Unsigned, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float32)
-                throw new StackTypeInvalidException(OpCode.Int64TruncateFloat32Unsigned, WebAssemblyValueType.Float32, type);
+            context.PopStack(OpCode.Int64TruncateFloat32Unsigned, WebAssemblyValueType.Float32);
 
             context.Emit(OpCodes.Conv_Ovf_I8_Un);
 

--- a/WebAssembly/Instructions/Int64TruncateFloat64Signed.cs
+++ b/WebAssembly/Instructions/Int64TruncateFloat64Signed.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Int64TruncateFloat64Signed, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float64)
-                throw new StackTypeInvalidException(OpCode.Int64TruncateFloat64Signed, WebAssemblyValueType.Float64, type);
+            context.PopStack(OpCode.Int64TruncateFloat64Signed, WebAssemblyValueType.Float64);
 
             context.Emit(OpCodes.Conv_Ovf_I8);
 

--- a/WebAssembly/Instructions/Int64TruncateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateFloat64Unsigned.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(OpCode.Int64TruncateFloat64Unsigned, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Float64)
-                throw new StackTypeInvalidException(OpCode.Int64TruncateFloat64Unsigned, WebAssemblyValueType.Float64, type);
+            context.PopStack(OpCode.Int64TruncateFloat64Unsigned, WebAssemblyValueType.Float64);
 
             context.Emit(OpCodes.Conv_Ovf_I8_Un);
 

--- a/WebAssembly/Instructions/LocalSet.cs
+++ b/WebAssembly/Instructions/LocalSet.cs
@@ -37,13 +37,7 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.LocalSet, 1, stack.Count);
-
-            var setType = stack.Pop();
-            if (setType != context.CheckedLocals[this.Index])
-                throw new StackTypeInvalidException(OpCode.LocalSet, context.CheckedLocals[this.Index], setType);
+            context.PopStack(OpCode.LocalSet, context.CheckedLocals[this.Index]);
 
             var localIndex = this.Index - context.CheckedSignature.ParameterTypes.Length;
             if (localIndex < 0)

--- a/WebAssembly/Instructions/LocalTee.cs
+++ b/WebAssembly/Instructions/LocalTee.cs
@@ -37,13 +37,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.LocalTee, 1, stack.Count);
-
-            var setType = stack.Peek();  //Assuming validation passes, the remaining type will be this.
-            if (setType != context.CheckedLocals[this.Index])
-                throw new StackTypeInvalidException(OpCode.LocalTee, context.CheckedLocals[this.Index], setType);
+            //Assuming validation passes, the remaining type will be context.CheckedLocals[this.Index]).
+            context.PeekStack(OpCode.LocalTee, context.CheckedLocals[this.Index]);
 
             context.Emit(OpCodes.Dup);
 

--- a/WebAssembly/Instructions/Loop.cs
+++ b/WebAssembly/Instructions/Loop.cs
@@ -38,7 +38,7 @@ namespace WebAssembly.Instructions
             var loopStart = context.DefineLabel();
             context.Labels.Add(checked((uint)context.Depth.Count), loopStart);
             context.Depth.Push(Type);
-            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack));
+            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack.Count));
             context.MarkLabel(loopStart);
             context.LoopLabels.Add(loopStart);
         }

--- a/WebAssembly/Instructions/Loop.cs
+++ b/WebAssembly/Instructions/Loop.cs
@@ -38,6 +38,7 @@ namespace WebAssembly.Instructions
             var loopStart = context.DefineLabel();
             context.Labels.Add(checked((uint)context.Depth.Count), loopStart);
             context.Depth.Push(Type);
+            context.BlockContexts.Add(checked((uint)context.Depth.Count), new BlockContext(context.Stack));
             context.MarkLabel(loopStart);
             context.LoopLabels.Add(loopStart);
         }

--- a/WebAssembly/Instructions/MemoryGrow.cs
+++ b/WebAssembly/Instructions/MemoryGrow.cs
@@ -55,13 +55,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(OpCode.MemoryGrow, 1, stack.Count);
-
-            var type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.MemoryGrow, WebAssemblyValueType.Int32, type);
+            //Assuming validation passes, the remaining type will be Int32.
+            context.PeekStack(OpCode.MemoryGrow, WebAssemblyValueType.Int32);
 
             context.EmitLoadThis();
             context.Emit(OpCodes.Ldfld, context.CheckedMemory);

--- a/WebAssembly/Instructions/MemoryReadInstruction.cs
+++ b/WebAssembly/Instructions/MemoryReadInstruction.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(this.OpCode, 1, 0);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int32, type);
+            context.PopStack(this.OpCode, WebAssemblyValueType.Int32);
 
             if (this.Offset != 0)
             {

--- a/WebAssembly/Instructions/MemoryWriteInstruction.cs
+++ b/WebAssembly/Instructions/MemoryWriteInstruction.cs
@@ -23,17 +23,7 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 2)
-                throw new StackTooSmallException(this.OpCode, 2, stack.Count);
-
-            var type = stack.Pop();
-            if (type != this.Type)
-                throw new StackTypeInvalidException(this.OpCode, this.Type, type);
-
-            type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(this.OpCode, WebAssemblyValueType.Int32, type);
+            context.PopStack(this.OpCode, this.Type, WebAssemblyValueType.Int32);
 
             Int32Constant.Emit(context, (int)this.Offset);
             context.EmitLoadThis();

--- a/WebAssembly/Instructions/Return.cs
+++ b/WebAssembly/Instructions/Return.cs
@@ -56,8 +56,8 @@ namespace WebAssembly.Instructions
 
             context.Emit(OpCodes.Ret);
 
-            //Mark the following code within this block is unreachable
-            context.MarkUnreachable();
+            //Mark the subsequent code within this function is unreachable
+            context.MarkUnreachable(functionWide: true);
         }
     }
 }

--- a/WebAssembly/Instructions/Return.cs
+++ b/WebAssembly/Instructions/Return.cs
@@ -32,9 +32,6 @@ namespace WebAssembly.Instructions
 
             var stackCount = stack.Count;
 
-            if (stackCount < returnsLength)
-                throw new StackTooSmallException(OpCode.Return, returnsLength, 0);
-
             if (stackCount > returnsLength)
             {
                 if (returnsLength == 0)
@@ -53,14 +50,14 @@ namespace WebAssembly.Instructions
                     context.Emit(OpCodes.Ldloc, value.LocalIndex);
                 }
             }
-            else if (returnsLength == 1)
-            {
-                var type = stack.Pop();
-                if (type != returns[0])
-                    throw new StackTypeInvalidException(OpCode.Return, returns[0], type);
-            }
+
+            if (returnsLength == 1)
+                context.PopStack(OpCode.Return, returns[0]);
 
             context.Emit(OpCodes.Ret);
+
+            //Mark the following code within this block is unreachable
+            context.MarkUnreachable();
         }
     }
 }

--- a/WebAssembly/Instructions/Select.cs
+++ b/WebAssembly/Instructions/Select.cs
@@ -25,18 +25,23 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 3)
-                throw new StackTooSmallException(OpCode.Select, 3, stack.Count);
 
-            var type = stack.Pop();
-            if (type != WebAssemblyValueType.Int32)
-                throw new StackTypeInvalidException(OpCode.Select, WebAssemblyValueType.Int32, type);
+            var popped = context.PopStack(OpCode.Select, WebAssemblyValueType.Int32, null, null);
+            var typeB = popped[1];
+            var typeA = popped[2];
 
-            var typeB = stack.Pop();
-            var typeA = stack.Peek(); //Assuming validation passes, the remaining type will be this.
+            if (typeA != typeB && typeA.HasValue && typeB.HasValue)
+                throw new StackTypeInvalidException(OpCode.Select, typeA.Value, typeB.Value);
 
-            if (typeA != typeB)
-                throw new StackParameterMismatchException(OpCode.Select, typeA, typeB);
+            if (!typeA.HasValue)
+                stack.Push(typeB);
+            else
+                stack.Push(typeA);
+
+            if (!typeA.HasValue)
+            {
+                typeA = WebAssemblyValueType.Int32; //And treat it as an int32
+            }
 
             HelperMethod helper;
             switch (typeA)

--- a/WebAssembly/Instructions/TruncateSaturateInstruction.cs
+++ b/WebAssembly/Instructions/TruncateSaturateInstruction.cs
@@ -24,12 +24,8 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(MiscellaneousOpCode, 1, 0);
 
-            var type = stack.Pop();
-            if (type != InputValueType)
-                throw new StackTypeInvalidException(MiscellaneousOpCode, InputValueType, type);
+            context.PopStack(this.OpCode, InputValueType);
 
             context.Emit(OpCodes.Call, context[ConversionHelper, (helper, c) =>
             {

--- a/WebAssembly/Instructions/Unreachable.cs
+++ b/WebAssembly/Instructions/Unreachable.cs
@@ -29,8 +29,8 @@ namespace WebAssembly.Instructions
             context.Emit(OpCodes.Newobj, typeof(UnreachableException).GetTypeInfo().DeclaredConstructors.First(c => c.GetParameters().Length == 0));
             context.Emit(OpCodes.Throw);
 
-            //Mark the following code within this block is unreachable
-            context.MarkUnreachable();
+            //Mark the subsequent code within this function is unreachable
+            context.MarkUnreachable(functionWide: true);
         }
     }
 }

--- a/WebAssembly/Instructions/Unreachable.cs
+++ b/WebAssembly/Instructions/Unreachable.cs
@@ -28,6 +28,9 @@ namespace WebAssembly.Instructions
         {
             context.Emit(OpCodes.Newobj, typeof(UnreachableException).GetTypeInfo().DeclaredConstructors.First(c => c.GetParameters().Length == 0));
             context.Emit(OpCodes.Throw);
+
+            //Mark the following code within this block is unreachable
+            context.MarkUnreachable();
         }
     }
 }

--- a/WebAssembly/Instructions/ValueOneToOneCallInstruction.cs
+++ b/WebAssembly/Instructions/ValueOneToOneCallInstruction.cs
@@ -20,13 +20,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count == 0)
-                throw new StackTooSmallException(this.OpCode, 1, 0);
-
-            var type = stack.Peek();  //Assuming validation passes, the remaining type will be this.
-            if (type != this.ValueType)
-                throw new StackTypeInvalidException(this.OpCode, this.ValueType, type);
+            //Assuming validation passes, the remaining type will be this.ValueType.
+            context.PeekStack(this.OpCode, this.ValueType);
 
             context.Emit(OpCodes.Call, this.MethodInfo);
         }

--- a/WebAssembly/Instructions/ValueOneToOneInstruction.cs
+++ b/WebAssembly/Instructions/ValueOneToOneInstruction.cs
@@ -18,14 +18,8 @@ namespace WebAssembly.Instructions
 
         internal sealed override void Compile(CompilationContext context)
         {
-            var stack = context.Stack;
-            if (stack.Count < 1)
-                throw new StackTooSmallException(this.OpCode, 1, stack.Count);
-
-            var type = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (type != this.ValueType)
-                throw new StackTypeInvalidException(this.OpCode, this.ValueType, type);
+            //Assuming validation passes, the remaining type will be this.ValueType.
+            context.PeekStack(this.OpCode, this.ValueType);
 
             context.Emit(this.EmittedOpCode);
         }

--- a/WebAssembly/Instructions/ValueTwoToInt32Instruction.cs
+++ b/WebAssembly/Instructions/ValueTwoToInt32Instruction.cs
@@ -19,17 +19,8 @@ namespace WebAssembly.Instructions
         internal override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 2)
-                throw new StackTooSmallException(this.OpCode, 2, stack.Count);
 
-            var typeB = stack.Pop();
-            var typeA = stack.Pop();
-
-            if (typeA != this.ValueType)
-                throw new StackTypeInvalidException(this.OpCode, this.ValueType, typeA);
-
-            if (typeA != typeB)
-                throw new StackParameterMismatchException(this.OpCode, typeA, typeB);
+            context.PopStack(this.OpCode, this.ValueType, this.ValueType);
 
             stack.Push(WebAssemblyValueType.Int32);
 

--- a/WebAssembly/Instructions/ValueTwoToOneCallInstruction.cs
+++ b/WebAssembly/Instructions/ValueTwoToOneCallInstruction.cs
@@ -21,17 +21,9 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 2)
-                throw new StackTooSmallException(this.OpCode, 2, stack.Count);
 
-            var typeB = stack.Pop();
-            var typeA = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (typeA != this.ValueType)
-                throw new StackTypeInvalidException(this.OpCode, this.ValueType, typeA);
-
-            if (typeA != typeB)
-                throw new StackParameterMismatchException(this.OpCode, typeA, typeB);
+            context.PopStack(this.OpCode, this.ValueType, this.ValueType);
+            stack.Push(this.ValueType);
 
             context.Emit(OpCodes.Call, this.MethodInfo);
         }

--- a/WebAssembly/Instructions/ValueTwoToOneInstruction.cs
+++ b/WebAssembly/Instructions/ValueTwoToOneInstruction.cs
@@ -19,17 +19,9 @@ namespace WebAssembly.Instructions
         internal sealed override void Compile(CompilationContext context)
         {
             var stack = context.Stack;
-            if (stack.Count < 2)
-                throw new StackTooSmallException(this.OpCode, 2, stack.Count);
-
-            var typeB = stack.Pop();
-            var typeA = stack.Peek(); //Assuming validation passes, the remaining type will be this.
-
-            if (typeA != this.ValueType)
-                throw new StackTypeInvalidException(this.OpCode, this.ValueType, typeA);
-
-            if (typeA != typeB)
-                throw new StackParameterMismatchException(this.OpCode, typeA, typeB);
+            
+            context.PopStack(this.OpCode, this.ValueType, this.ValueType);
+            stack.Push(this.ValueType);
 
             context.Emit(this.EmittedOpCode);
         }

--- a/WebAssembly/Runtime/Compilation/BlockContext.cs
+++ b/WebAssembly/Runtime/Compilation/BlockContext.cs
@@ -7,18 +7,18 @@ namespace WebAssembly.Runtime.Compilation
     /// </summary>
     internal sealed class BlockContext
     {
-        public readonly WebAssemblyValueType?[] InitialStack;
+        public readonly int InitialStackSize;
         public bool IsUnreachable { get; private set; }
 
         public BlockContext()
         {
             IsUnreachable = false;
-            InitialStack = new WebAssemblyValueType?[0];
+            InitialStackSize = 0;
         }
 
-        public BlockContext(Stack<WebAssemblyValueType?> initialStack)
+        public BlockContext(int initialStackSize)
         {
-            InitialStack = initialStack.ToArray();  //Copy stack
+            InitialStackSize = initialStackSize;
             IsUnreachable = false;
         }
 

--- a/WebAssembly/Runtime/Compilation/BlockContext.cs
+++ b/WebAssembly/Runtime/Compilation/BlockContext.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+
+namespace WebAssembly.Runtime.Compilation
+{
+    /// <summary>
+    /// Remembers stack state at the beginning of a block, and reachability of code.
+    /// </summary>
+    internal sealed class BlockContext
+    {
+        public readonly WebAssemblyValueType?[] InitialStack;
+        public bool IsUnreachable { get; private set; }
+
+        public BlockContext()
+        {
+            IsUnreachable = false;
+            InitialStack = new WebAssemblyValueType?[0];
+        }
+
+        public BlockContext(Stack<WebAssemblyValueType?> initialStack)
+        {
+            InitialStack = initialStack.ToArray();  //Copy stack
+            IsUnreachable = false;
+        }
+
+        public void MarkUnreachable()
+        {
+            IsUnreachable = true;
+        }
+
+        public void MarkReachable()
+        {
+            IsUnreachable = false;
+        }
+    }
+}

--- a/WebAssembly/Runtime/Compilation/CompilationContext.cs
+++ b/WebAssembly/Runtime/Compilation/CompilationContext.cs
@@ -200,7 +200,7 @@ namespace WebAssembly.Runtime.Compilation
             {
                 WebAssemblyValueType? type;
 
-                if (this.Stack.Count <= blockContext.InitialStack.Length)
+                if (this.Stack.Count <= blockContext.InitialStackSize)
                 {
                     if (blockContext.IsUnreachable)
                     {
@@ -252,7 +252,7 @@ namespace WebAssembly.Runtime.Compilation
             //Revert the stack state into beginning of the current block
             //This is based on the validation algorithm defined in WASM spec.
             //See: https://webassembly.github.io/spec/core/appendix/algorithm.html
-            while (this.Stack.Count > blockContext.InitialStack.Length)
+            while (this.Stack.Count > blockContext.InitialStackSize)
             {
                 this.Stack.Pop();
             }

--- a/WebAssembly/Runtime/Compilation/CompilationContext.cs
+++ b/WebAssembly/Runtime/Compilation/CompilationContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -58,6 +59,8 @@ namespace WebAssembly.Runtime.Compilation
             this.Labels.Clear();
             this.LoopLabels.Clear();
             this.Stack.Clear();
+            this.BlockContexts.Clear();
+            this.BlockContexts.Add(checked((uint)this.Depth.Count), new BlockContext());
         }
 
         public Signature[]? FunctionSignatures;
@@ -119,7 +122,9 @@ namespace WebAssembly.Runtime.Compilation
 
         public readonly HashSet<Label> LoopLabels = new HashSet<Label>();
 
-        public readonly Stack<WebAssemblyValueType> Stack = new Stack<WebAssemblyValueType>();
+        public readonly Stack<WebAssemblyValueType?> Stack = new Stack<WebAssemblyValueType?>();
+
+        public readonly Dictionary<uint, BlockContext> BlockContexts = new Dictionary<uint, BlockContext>();
 
         public WebAssemblyValueType[] CheckedLocals => Locals ?? throw new InvalidOperationException();
 
@@ -176,5 +181,86 @@ namespace WebAssembly.Runtime.Compilation
         public void Emit(System.Reflection.Emit.OpCode opcode, ConstructorInfo con) => CheckedGenerator.Emit(opcode, con);
 
         public LocalBuilder DeclareLocal(Type localType) => CheckedGenerator.DeclareLocal(localType);
+
+        /// <summary>
+        /// Pop multiple types from stack and test whether they match with expected types.
+        /// The algorithm is based on the validation algorithm described in WASM spec.
+        /// See: https://webassembly.github.io/spec/core/appendix/algorithm.html
+        /// </summary>
+        /// <param name="opcode">OpCode of the instruction (for exception message).</param>
+        /// <param name="expectedTypes">Array of expected types (or null, which indicates any type is accepted), in </param>
+        /// <returns>Array of actually popped types (or null, which indicates unknown type).</returns>
+        public WebAssemblyValueType?[] PopStack(OpCode opcode, params WebAssemblyValueType?[] expectedTypes)
+        {
+            var actualTypes = new List<WebAssemblyValueType?>();
+            var initialStackSize = this.Stack.Count;
+            var blockContext = this.BlockContexts[checked((uint)this.Depth.Count)];
+
+            foreach (var expected in expectedTypes)
+            {
+                WebAssemblyValueType? type;
+
+                if (this.Stack.Count <= blockContext.InitialStack.Length)
+                {
+                    if (blockContext.IsUnreachable)
+                    {
+                        //unreachable, br, br_table, return can "make up" arbitrary types
+                        type = null;
+                    }
+                    else
+                    {
+                        throw new StackTooSmallException(opcode, expectedTypes.Length, initialStackSize);
+                    }
+                }
+                else
+                {
+                    type = this.Stack.Pop();
+                }
+
+                if (type.HasValue)
+                {
+                    if (expected.HasValue && type != expected)
+                        throw new StackTypeInvalidException(opcode, expected.Value, type.Value);
+                }
+                else
+                {
+                    type = expected;
+                }
+
+                actualTypes.Add(type);
+            }
+
+            return actualTypes.ToArray();
+        }
+
+        public WebAssemblyValueType?[] PeekStack(OpCode opcode, params WebAssemblyValueType?[] expectedTypes)
+        {
+            var popped = this.PopStack(opcode, expectedTypes);
+            foreach (var type in popped.Reverse())
+            {
+                this.Stack.Push(type);
+            }
+
+            return popped;
+        }
+
+        public void MarkUnreachable()
+        {
+            var blockContext = this.BlockContexts[checked((uint)this.Depth.Count)];
+            blockContext.MarkUnreachable();
+
+            //Revert the stack state into beginning of the current block
+            //This is based on the validation algorithm defined in WASM spec.
+            //See: https://webassembly.github.io/spec/core/appendix/algorithm.html
+            while (this.Stack.Count > blockContext.InitialStack.Length)
+            {
+                this.Stack.Pop();
+            }
+        }
+
+        public void MarkReachable()
+        {
+            this.BlockContexts[checked((uint)this.Depth.Count)].MarkReachable();
+        }
     }
 }

--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -1162,6 +1162,7 @@ namespace WebAssembly.Runtime
                                     context.Previous = instruction.OpCode;
                                 }
                                 context.Stack.Pop();
+                                context.BlockContexts.Remove(checked((uint)context.Depth.Count));
                                 instanceConstructorIL.Emit(OpCodes.Stloc, address);
 
                                 var data = reader.ReadBytes(reader.ReadVarUInt32());

--- a/WebAssembly/Runtime/LabelTypeMismatchException.cs
+++ b/WebAssembly/Runtime/LabelTypeMismatchException.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WebAssembly.Runtime
+{
+    /// <summary>
+    /// Used by the compiler to indicate that the labels of a br_table instruction does not have the same type.
+    /// </summary>
+    public class LabelTypeMismatchException : OpCodeCompilationException
+    {
+        /// <summary>
+        /// Creates a new <see cref="LabelTypeMismatchException"/> with the provided parameters.
+        /// </summary>
+        /// <param name="opCode">The operation attempted.</param>
+        /// <param name="expected">The expected label type (type of the default label).</param>
+        /// <param name="actual">The actual label type.</param>
+        public LabelTypeMismatchException(OpCode opCode, BlockType expected, BlockType actual)
+            : base(opCode, $"requires all labels to have type {expected}, but found {actual}.")
+        {
+            this.Expected = expected;
+            this.Actual = actual;
+        }
+
+        /// <summary>
+        /// The expected label type (type of the default label).
+        /// </summary>
+        public BlockType Expected { get; }
+
+        /// <summary>
+        /// The actual label type.
+        /// </summary>
+        public BlockType Actual { get; }
+    }
+}


### PR DESCRIPTION
This PR allows compilation of WASM codes which previously generated compile error.
In particular, it fixes some unnecessary compile errors related to unreachable code.
For example.
- Issue #21 (GreenGood's `wasm.zip` successfully compiles, aside from lack of imports)
- `SpecTest_unreachable`, `SpecTest_return`, `SpecTest_select` (`[Ignore("StackTooSmallException")]` was removed from those tests, and still passing)

However, many modifications were needed.
I used the algorithm based on [the Validation Algorithm described in the WASM spec](https://webassembly.github.io/spec/core/appendix/algorithm.html).
This is the list of major changes:
- Created `BlockContext` mechanism, which remembers stack height and reachability of a block (similar to `ctrl_frame` in [WASM spec](https://webassembly.github.io/spec/core/appendix/algorithm.html))
- `CompilationContext.PopStack`/`PeekStack` methods instead of directly accessing stack. These methods do stack manipulation and type check considering unreachability.
- Stack is changed to `Stack<WebAssemblyValueType?>`. `null` is used to represent `unknown type` (as in the algorithm in [WASM spec](https://webassembly.github.io/spec/core/appendix/algorithm.html))
- Added type-check of labels.
- Added `LabelTypeMismatchException`, which is thrown when a `br_table` has target labels of inconsistent types.

(This is a rewrite of the withdrawn PR #29 )