### PR TITLE
Fix InvalidProgramException

### DIFF
--- a/WebAssembly.Tests/Instructions/Int64ShiftLeftTests.cs
+++ b/WebAssembly.Tests/Instructions/Int64ShiftLeftTests.cs
@@ -14,9 +14,6 @@ namespace WebAssembly.Instructions
         [TestMethod]
         public void Int64ShiftLeft_Compiled()
         {
-            if (!System.Environment.Is64BitProcess)
-                Assert.Inconclusive("32-bit .NET doesn't support 64-bit bit shift amounts.");
-
             const int amount = 0xF;
 
             var exports = CompilerTestBase<long>.CreateInstance(

--- a/WebAssembly.Tests/Instructions/Int64ShiftRightSignedTests.cs
+++ b/WebAssembly.Tests/Instructions/Int64ShiftRightSignedTests.cs
@@ -14,9 +14,6 @@ namespace WebAssembly.Instructions
         [TestMethod]
         public void Int64ShiftRightSigned_Compiled()
         {
-            if (!System.Environment.Is64BitProcess)
-                Assert.Inconclusive("32-bit .NET doesn't support 64-bit bit shift amounts.");
-
             const int amount = 0xF;
 
             var exports = CompilerTestBase<long>.CreateInstance(

--- a/WebAssembly.Tests/WebAssembly.Tests.csproj
+++ b/WebAssembly.Tests/WebAssembly.Tests.csproj
@@ -6,13 +6,22 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netcoreapp1.1\WebAssembly.Tests.xml</DocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <DocumentationFile>bin\Debug\netcoreapp1.1\WebAssembly.Tests.xml</DocumentationFile>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netcoreapp1.1\WebAssembly.Tests.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <DocumentationFile>bin\Release\netcoreapp1.1\WebAssembly.Tests.xml</DocumentationFile>
   </PropertyGroup>
 

--- a/WebAssembly.sln
+++ b/WebAssembly.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAssembly", "WebAssembly\WebAssembly.csproj", "{E9676C8C-A671-4978-8C62-40BBA257A597}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebAssembly", "WebAssembly\WebAssembly.csproj", "{E9676C8C-A671-4978-8C62-40BBA257A597}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAssembly.Tests", "WebAssembly.Tests\WebAssembly.Tests.csproj", "{E76A6235-3CE7-4E06-ACEB-21673E59C461}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebAssembly.Tests", "WebAssembly.Tests\WebAssembly.Tests.csproj", "{E76A6235-3CE7-4E06-ACEB-21673E59C461}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{40D02F4C-D45F-45BE-99DF-D1E48B7CF621}"
 	ProjectSection(SolutionItems) = preProject
@@ -18,19 +18,32 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E9676C8C-A671-4978-8C62-40BBA257A597}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E9676C8C-A671-4978-8C62-40BBA257A597}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9676C8C-A671-4978-8C62-40BBA257A597}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9676C8C-A671-4978-8C62-40BBA257A597}.Debug|x86.Build.0 = Debug|Any CPU
 		{E9676C8C-A671-4978-8C62-40BBA257A597}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9676C8C-A671-4978-8C62-40BBA257A597}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9676C8C-A671-4978-8C62-40BBA257A597}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9676C8C-A671-4978-8C62-40BBA257A597}.Release|x86.Build.0 = Release|Any CPU
 		{E76A6235-3CE7-4E06-ACEB-21673E59C461}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E76A6235-3CE7-4E06-ACEB-21673E59C461}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E76A6235-3CE7-4E06-ACEB-21673E59C461}.Debug|x86.ActiveCfg = Debug|x86
+		{E76A6235-3CE7-4E06-ACEB-21673E59C461}.Debug|x86.Build.0 = Debug|x86
 		{E76A6235-3CE7-4E06-ACEB-21673E59C461}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E76A6235-3CE7-4E06-ACEB-21673E59C461}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E76A6235-3CE7-4E06-ACEB-21673E59C461}.Release|x86.ActiveCfg = Release|x86
+		{E76A6235-3CE7-4E06-ACEB-21673E59C461}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3B09C795-39DB-4388-9441-FA9401CFD4BE}
 	EndGlobalSection
 EndGlobal

--- a/WebAssembly/Instructions/Int64CountLeadingZeroes.cs
+++ b/WebAssembly/Instructions/Int64CountLeadingZeroes.cs
@@ -79,7 +79,8 @@ namespace WebAssembly.Instructions
                 il.Emit(OpCodes.Or);
                 il.Emit(OpCodes.Starg_S, 0);
 
-                il.Emit(OpCodes.Ldc_I4_S, 64);
+                il.Emit(OpCodes.Ldc_I4, 64);
+                il.Emit(OpCodes.Conv_I8);
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Call, c[HelperMethod.Int64CountOneBits, Int64CountOneBits.CreateHelper]);
                 il.Emit(OpCodes.Sub);

--- a/WebAssembly/Instructions/Int64CountLeadingZeroes.cs
+++ b/WebAssembly/Instructions/Int64CountLeadingZeroes.cs
@@ -79,7 +79,7 @@ namespace WebAssembly.Instructions
                 il.Emit(OpCodes.Or);
                 il.Emit(OpCodes.Starg_S, 0);
 
-                il.Emit(OpCodes.Ldc_I4, 64);
+                il.Emit(OpCodes.Ldc_I4_S, 64);
                 il.Emit(OpCodes.Conv_I8);
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Call, c[HelperMethod.Int64CountOneBits, Int64CountOneBits.CreateHelper]);

--- a/WebAssembly/Instructions/Int64ShiftLeft.cs
+++ b/WebAssembly/Instructions/Int64ShiftLeft.cs
@@ -1,25 +1,35 @@
+using System.Reflection.Emit;
+using WebAssembly.Runtime.Compilation;
+
 namespace WebAssembly.Instructions
 {
     /// <summary>
     /// Sign-agnostic shift left.
     /// </summary>
-    public class Int64ShiftLeft : ValueTwoToOneInstruction
+    public class Int64ShiftLeft : SimpleInstruction
     {
         /// <summary>
         /// Always <see cref="OpCode.Int64ShiftLeft"/>.
         /// </summary>
         public sealed override OpCode OpCode => OpCode.Int64ShiftLeft;
 
-        private protected sealed override WebAssemblyValueType ValueType => WebAssemblyValueType.Int64;
-
-        private protected sealed override System.Reflection.Emit.OpCode EmittedOpCode =>
-            System.Reflection.Emit.OpCodes.Shl;
-
         /// <summary>
         /// Creates a new  <see cref="Int64ShiftLeft"/> instance.
         /// </summary>
         public Int64ShiftLeft()
         {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int64, WebAssemblyValueType.Int64);
+
+            //Unlike WASM, CIL OpCodes.Shl requires the shift amount to be int32 or native int
+            //See: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shl?view=net-5.0
+            context.Emit(OpCodes.Conv_I4);  //Convert shift amount into int32
+            context.Emit(OpCodes.Shl);
+
+            context.Stack.Push(WebAssemblyValueType.Int64);
         }
     }
 }

--- a/WebAssembly/Instructions/Int64ShiftLeft.cs
+++ b/WebAssembly/Instructions/Int64ShiftLeft.cs
@@ -26,7 +26,7 @@ namespace WebAssembly.Instructions
 
             //Unlike WASM, CIL OpCodes.Shl requires the shift amount to be int32 or native int
             //See: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shl?view=net-5.0
-            context.Emit(OpCodes.Conv_I4);  //Convert shift amount into int32
+            context.Emit(OpCodes.Conv_I);  //Convert shift amount into native int
             context.Emit(OpCodes.Shl);
 
             context.Stack.Push(WebAssemblyValueType.Int64);

--- a/WebAssembly/Instructions/Int64ShiftRightSigned.cs
+++ b/WebAssembly/Instructions/Int64ShiftRightSigned.cs
@@ -26,7 +26,7 @@ namespace WebAssembly.Instructions
 
             //Unlike WASM, CIL OpCodes.Shr requires the shift amount to be int32 or native int.
             //See: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shr?view=net-5.0
-            context.Emit(OpCodes.Conv_I4);  //Convert shift amount into int32
+            context.Emit(OpCodes.Conv_I);  //Convert shift amount into native int
             context.Emit(OpCodes.Shr);
 
             context.Stack.Push(WebAssemblyValueType.Int64);

--- a/WebAssembly/Instructions/Int64ShiftRightSigned.cs
+++ b/WebAssembly/Instructions/Int64ShiftRightSigned.cs
@@ -1,25 +1,35 @@
+using System.Reflection.Emit;
+using WebAssembly.Runtime.Compilation;
+
 namespace WebAssembly.Instructions
 {
     /// <summary>
     /// Zero-replicating (logical) shift right.
     /// </summary>
-    public class Int64ShiftRightSigned : ValueTwoToOneInstruction
+    public class Int64ShiftRightSigned : SimpleInstruction
     {
         /// <summary>
         /// Always <see cref="OpCode.Int64ShiftRightSigned"/>.
         /// </summary>
         public sealed override OpCode OpCode => OpCode.Int64ShiftRightSigned;
 
-        private protected sealed override WebAssemblyValueType ValueType => WebAssemblyValueType.Int64;
-
-        private protected sealed override System.Reflection.Emit.OpCode EmittedOpCode =>
-            System.Reflection.Emit.OpCodes.Shr;
-
         /// <summary>
         /// Creates a new  <see cref="Int64ShiftRightSigned"/> instance.
         /// </summary>
         public Int64ShiftRightSigned()
         {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int64, WebAssemblyValueType.Int64);
+
+            //Unlike WASM, CIL OpCodes.Shr requires the shift amount to be int32 or native int.
+            //See: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shr?view=net-5.0
+            context.Emit(OpCodes.Conv_I4);  //Convert shift amount into int32
+            context.Emit(OpCodes.Shr);
+
+            context.Stack.Push(WebAssemblyValueType.Int64);
         }
     }
 }

--- a/WebAssembly/Instructions/Int64ShiftRightUnsigned.cs
+++ b/WebAssembly/Instructions/Int64ShiftRightUnsigned.cs
@@ -1,25 +1,35 @@
+using System.Reflection.Emit;
+using WebAssembly.Runtime.Compilation;
+
 namespace WebAssembly.Instructions
 {
     /// <summary>
     ///Sign-replicating (arithmetic) shift right.
     /// </summary>
-    public class Int64ShiftRightUnsigned : ValueTwoToOneInstruction
+    public class Int64ShiftRightUnsigned : SimpleInstruction
     {
         /// <summary>
         /// Always <see cref="OpCode.Int64ShiftRightUnsigned"/>.
         /// </summary>
         public sealed override OpCode OpCode => OpCode.Int64ShiftRightUnsigned;
 
-        private protected sealed override WebAssemblyValueType ValueType => WebAssemblyValueType.Int64;
-
-        private protected sealed override System.Reflection.Emit.OpCode EmittedOpCode =>
-            System.Reflection.Emit.OpCodes.Shr_Un;
-
         /// <summary>
         /// Creates a new  <see cref="Int64ShiftRightUnsigned"/> instance.
         /// </summary>
         public Int64ShiftRightUnsigned()
         {
+        }
+
+        internal sealed override void Compile(CompilationContext context)
+        {
+            context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int64, WebAssemblyValueType.Int64);
+
+            //Unlike WASM, CIL OpCodes.Shr_Un requires the shift amount to be int32 or native int.
+            //See: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shr_un?view=net-5.0
+            context.Emit(OpCodes.Conv_I4);  //Convert shift amount into int32
+            context.Emit(OpCodes.Shr_Un);
+
+            context.Stack.Push(WebAssemblyValueType.Int64);
         }
     }
 }

--- a/WebAssembly/Instructions/Int64ShiftRightUnsigned.cs
+++ b/WebAssembly/Instructions/Int64ShiftRightUnsigned.cs
@@ -26,7 +26,7 @@ namespace WebAssembly.Instructions
 
             //Unlike WASM, CIL OpCodes.Shr_Un requires the shift amount to be int32 or native int.
             //See: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shr_un?view=net-5.0
-            context.Emit(OpCodes.Conv_I4);  //Convert shift amount into int32
+            context.Emit(OpCodes.Conv_I);  //Convert shift amount into native int
             context.Emit(OpCodes.Shr_Un);
 
             context.Stack.Push(WebAssemblyValueType.Int64);

--- a/WebAssembly/Instructions/MemoryReadInstruction.cs
+++ b/WebAssembly/Instructions/MemoryReadInstruction.cs
@@ -50,7 +50,11 @@ namespace WebAssembly.Instructions
                 case Options.Align8: alignment = 8; break;
             }
 
-            if (alignment != 4)
+            //8-byte alignment is not available in IL.
+            //See: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.unaligned?view=net-5.0
+            //However, because 8-byte alignment is subset of 4-byte alignment,
+            //We don't have to consider it.
+            if (alignment != 4 && alignment != 8)
                 context.Emit(OpCodes.Unaligned, alignment);
 
             context.Emit(this.EmittedOpCode);


### PR DESCRIPTION
This PR solves some `InvalidProgramException`s, which is thrown when executing broken IL.
Modifications are:
- Stopped using `unaligned. 8` IL instruction. Because [8-byte alignment is not supported in .NET](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.unaligned?view=net-5.0), using `unaligned. 8` caused an `InvalidProgramException`. Because 8-byte alignment is subset of 4-byte alignment, it was safely replaced by default 4-byte alignment.
  - This problem was noted in yself's [comment](https://github.com/RyanLamansky/dotnet-webassembly/issues/21#issuecomment-723051502) comment of #21.
- In `i64.(shl|shr|shr_s)` instructions, I added type conversion of shift amount operand. This is because [IL shift instructions only support 32-bit shift amount](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.shl?view=net-5.0).
- In IL of  `i64.clz` instruction, an explicit conversion from `int32` to `int64` was added.
  - This is probably unnecessary in .NET Framework, but needed for Mono (at least in Unity).
    - FYI, I use `dotnet-webassembly` on Unity through [forcibly compiling for .NET Framework 4.7.1](https://github.com/tana/dotnet-webassembly/commit/f65b5986fa094f1145305aa31a502635f7fbda0e).