### PR TITLE
Fix for "WebAssemblyValueType 7 not recognized" (#35)

### DIFF
--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -735,7 +735,7 @@ namespace WebAssembly.Runtime
 
                             var emptySignature = Signature.Empty;
 
-                            for (var i = 0; i < globals.Length; i++)
+                            for (var i = 0; i < count; i++)
                             {
                                 var contentType = (WebAssemblyValueType)reader.ReadVarInt7();
                                 var isMutable = reader.ReadVarUInt1() == 1;


### PR DESCRIPTION
When compiling a WASM binary, when there were N global imports in the
import section as well as M global variables in the global section, in
some (perhaps not all) circumstances, the compiler would try to read N+M
entries from the global section rather than just M.

In the reported issue, this resulted in an attempt to interpret the
adjacent bytes as the content type of the next global variable, which was
not a valid WebAssemblyValueType.

@RyanLamansky I wasn't sure where to put the test. CompilerTests.cs seemed like the right place, but after reading through it, nothing else tested `Compile.FromBinary` -- please let me know if there's a better place to put this or if I should create a new file.