### PR TITLE
Factor out Section_X methods for Global, Export, Start, Element, Code, and Data sections

### DIFF
--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -164,6 +164,37 @@ namespace WebAssembly.Runtime
             public readonly WebAssemblyValueType Type;
         }
 
+        const TypeAttributes classAttributes =
+            TypeAttributes.Public |
+            TypeAttributes.Class |
+            TypeAttributes.BeforeFieldInit
+            ;
+
+        const MethodAttributes constructorAttributes =
+            MethodAttributes.Public |
+            MethodAttributes.HideBySig |
+            MethodAttributes.SpecialName |
+            MethodAttributes.RTSpecialName
+            ;
+
+        const MethodAttributes internalFunctionAttributes =
+            MethodAttributes.Assembly |
+            MethodAttributes.Static |
+            MethodAttributes.HideBySig
+            ;
+
+        const MethodAttributes exportedFunctionAttributes =
+            MethodAttributes.Public |
+            MethodAttributes.Virtual |
+            MethodAttributes.Final |
+            MethodAttributes.HideBySig
+            ;
+
+        const FieldAttributes privateReadonlyField =
+            FieldAttributes.Private |
+            FieldAttributes.InitOnly
+            ;
+
         private static ConstructorInfo FromBinary(
             Reader reader,
             CompilerConfiguration configuration,
@@ -199,37 +230,6 @@ namespace WebAssembly.Runtime
                 AssemblyBuilderAccess.RunAndCollect
                 )
                 .DefineDynamicModule("CompiledWebAssembly")
-                ;
-
-            const TypeAttributes classAttributes =
-                TypeAttributes.Public |
-                TypeAttributes.Class |
-                TypeAttributes.BeforeFieldInit
-                ;
-
-            const MethodAttributes constructorAttributes =
-                MethodAttributes.Public |
-                MethodAttributes.HideBySig |
-                MethodAttributes.SpecialName |
-                MethodAttributes.RTSpecialName
-                ;
-
-            const MethodAttributes internalFunctionAttributes =
-                MethodAttributes.Assembly |
-                MethodAttributes.Static |
-                MethodAttributes.HideBySig
-                ;
-
-            const MethodAttributes exportedFunctionAttributes =
-                MethodAttributes.Public |
-                MethodAttributes.Virtual |
-                MethodAttributes.Final |
-                MethodAttributes.HideBySig
-                ;
-
-            const FieldAttributes privateReadonlyField =
-                FieldAttributes.Private |
-                FieldAttributes.InitOnly
                 ;
 
             var context = new CompilationContext(configuration);
@@ -721,485 +721,37 @@ namespace WebAssembly.Runtime
                         break;
 
                     case Section.Global:
-                        {
-                            var count = reader.ReadVarUInt32();
-                            if (globals != null)
-                            {
-                                Array.Resize(ref globals, checked((int)(globals.Length + count)));
-                                context.Globals = globals;
-                            }
-                            else
-                            {
-                                globals = context.Globals = new GlobalInfo[count];
-                            }
-
-                            var emptySignature = Signature.Empty;
-
-                            for (var i = 0; i < count; i++)
-                            {
-                                var contentType = (WebAssemblyValueType)reader.ReadVarInt7();
-                                var isMutable = reader.ReadVarUInt1() == 1;
-
-                                var getter = exportsBuilder.DefineMethod(
-                                    $"🌍 Get {i}",
-                                    internalFunctionAttributes,
-                                    CallingConventions.Standard,
-                                    contentType.ToSystemType(),
-                                    isMutable ? new Type[] { exports } : null
-                                    );
-
-                                var il = getter.GetILGenerator();
-                                var getterSignature = new Signature(contentType);
-                                MethodBuilder? setter;
-
-                                if (isMutable == false)
-                                {
-                                    context.Reset(
-                                        il,
-                                        getterSignature,
-                                        getterSignature.RawParameterTypes
-                                        );
-
-                                    foreach (var instruction in Instruction.ParseInitializerExpression(reader))
-                                    {
-                                        instruction.Compile(context);
-                                        context.Previous = instruction.OpCode;
-                                    }
-
-                                    setter = null;
-                                }
-                                else //Mutable
-                                {
-                                    var field = exportsBuilder.DefineField(
-                                        $"🌍 {i}",
-                                        contentType.ToSystemType(),
-                                        FieldAttributes.Private | (isMutable ? 0 : FieldAttributes.InitOnly)
-                                        );
-
-                                    il.Emit(OpCodes.Ldarg_0);
-                                    il.Emit(OpCodes.Ldfld, field);
-                                    il.Emit(OpCodes.Ret);
-
-                                    setter = exportsBuilder.DefineMethod(
-                                    $"🌍 Set {i}",
-                                        internalFunctionAttributes,
-                                        CallingConventions.Standard,
-                                        typeof(void),
-                                        new[] { contentType.ToSystemType(), exports }
-                                        );
-
-                                    il = setter.GetILGenerator();
-                                    il.Emit(OpCodes.Ldarg_1);
-                                    il.Emit(OpCodes.Ldarg_0);
-                                    il.Emit(OpCodes.Stfld, field);
-                                    il.Emit(OpCodes.Ret);
-
-                                    context.Reset(
-                                        instanceConstructorIL,
-                                        emptySignature,
-                                        emptySignature.RawParameterTypes
-                                        );
-
-                                    context.EmitLoadThis();
-                                    var ended = false;
-
-                                    foreach (var instruction in Instruction.ParseInitializerExpression(reader))
-                                    {
-                                        if (ended)
-                                            throw new CompilerException("Only a single End is allowed within an initializer expression.");
-
-                                        if (instruction.OpCode == OpCode.End)
-                                        {
-                                            context.Emit(OpCodes.Stfld, field);
-                                            ended = true;
-                                            continue;
-                                        }
-
-                                        instruction.Compile(context);
-                                        context.Previous = instruction.OpCode;
-                                    }
-                                }
-
-                                globals[importedGlobals + i] = new GlobalInfo(contentType, isMutable, getter, setter);
-                            }
-                        }
+                        globals = Section_Global(reader, context, globals, exportsBuilder, exports, instanceConstructorIL, importedGlobals);
                         break;
 
                     case Section.Export:
-                        {
-                            const MethodAttributes exportedPropertyAttributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.Virtual | MethodAttributes.Final;
-                            var totalExports = reader.ReadVarUInt32();
-                            var xFunctions = new List<KeyValuePair<string, uint>>((int)Math.Min(int.MaxValue, totalExports));
-
-                            for (var i = 0; i < totalExports; i++)
-                            {
-                                var name = reader.ReadString(reader.ReadVarUInt32());
-                                var preKindOffset = reader.Offset;
-                                var kind = (ExternalKind)reader.ReadByte();
-                                var preIndexOffset = reader.Offset;
-                                var index = reader.ReadVarUInt32();
-                                switch (kind)
-                                {
-                                    case ExternalKind.Function:
-                                        xFunctions.Add(new KeyValuePair<string, uint>(name, index));
-                                        break;
-                                    case ExternalKind.Table:
-                                        if (index != 0)
-                                            throw new ModuleLoadException($"Exported table must be of index 0, found {index}.", preIndexOffset);
-                                        if (functionTable == null)
-                                            throw new ModuleLoadException("Can't export a table without defining or importing one.", preKindOffset);
-
-                                        {
-                                            var tableGetter = exportsBuilder.DefineMethod("get_" + name,
-                                                exportedPropertyAttributes,
-                                                CallingConventions.HasThis,
-                                                typeof(FunctionTable),
-                                                emptyTypes
-                                                );
-                                            tableGetter.SetCustomAttribute(NativeExportAttribute.Emit(ExternalKind.Table, name));
-                                            var getterIL = tableGetter.GetILGenerator();
-                                            getterIL.Emit(OpCodes.Ldarg_0);
-                                            getterIL.Emit(OpCodes.Ldfld, functionTable);
-                                            getterIL.Emit(OpCodes.Ret);
-
-                                            exportsBuilder.DefineProperty(name, PropertyAttributes.None, typeof(FunctionTable), emptyTypes)
-                                                .SetGetMethod(tableGetter);
-                                        }
-                                        break;
-                                    case ExternalKind.Memory:
-                                        if (index != 0)
-                                            throw new ModuleLoadException($"Exported memory must be of index 0, found {index}.", preIndexOffset);
-                                        if (memory == null)
-                                            throw new CompilerException("Cannot export linear memory when linear memory is not defined.");
-
-                                        {
-                                            var memoryGetter = exportsBuilder.DefineMethod("get_" + name,
-                                                exportedPropertyAttributes,
-                                                CallingConventions.HasThis,
-                                                typeof(UnmanagedMemory),
-                                                emptyTypes
-                                                );
-                                            memoryGetter.SetCustomAttribute(NativeExportAttribute.Emit(ExternalKind.Memory, name));
-                                            var getterIL = memoryGetter.GetILGenerator();
-                                            getterIL.Emit(OpCodes.Ldarg_0);
-                                            getterIL.Emit(OpCodes.Ldfld, memory);
-                                            getterIL.Emit(OpCodes.Ret);
-
-                                            exportsBuilder.DefineProperty(name, PropertyAttributes.None, typeof(UnmanagedMemory), emptyTypes)
-                                                .SetGetMethod(memoryGetter);
-                                        }
-                                        break;
-                                    case ExternalKind.Global:
-                                        if (globals == null)
-                                            throw new ModuleLoadException($"Exported index {index} is global but no globals are defined.", preIndexOffset);
-                                        if (index >= globals.Length)
-                                            throw new ModuleLoadException($"Exported global index of {index} is greater than the number of globals {globals.Length}.", preIndexOffset);
-
-                                        {
-                                            var global = globals[index];
-                                            var property = exportsBuilder.DefineProperty(name, PropertyAttributes.None, global.Type.ToSystemType(), emptyTypes);
-                                            property.SetCustomAttribute(NativeExportAttribute.Emit(ExternalKind.Global, name));
-                                            var wrappedGet = exportsBuilder.DefineMethod("get_" + name,
-                                                exportedPropertyAttributes,
-                                                CallingConventions.HasThis,
-                                                global.Type.ToSystemType(),
-                                                emptyTypes
-                                                );
-
-                                            var wrappedGetIL = wrappedGet.GetILGenerator();
-                                            if (global.RequiresInstance)
-                                                wrappedGetIL.Emit(OpCodes.Ldarg_0);
-                                            wrappedGetIL.Emit(OpCodes.Call, global.Getter);
-                                            wrappedGetIL.Emit(OpCodes.Ret);
-                                            property.SetGetMethod(wrappedGet);
-
-                                            var setter = global.Setter;
-                                            if (setter != null)
-                                            {
-                                                var wrappedSet = exportsBuilder.DefineMethod("set_" + name,
-                                                    exportedPropertyAttributes,
-                                                    CallingConventions.HasThis,
-                                                    null,
-                                                    new[] { global.Type.ToSystemType() }
-                                                    );
-
-                                                var wrappedSetIL = wrappedSet.GetILGenerator();
-                                                wrappedSetIL.Emit(OpCodes.Ldarg_1);
-                                                if (global.RequiresInstance)
-                                                    wrappedSetIL.Emit(OpCodes.Ldarg_0);
-                                                wrappedSetIL.Emit(OpCodes.Call, setter);
-                                                wrappedSetIL.Emit(OpCodes.Ret);
-
-                                                property.SetSetMethod(wrappedSet);
-                                            }
-                                        }
-                                        break;
-                                    default:
-                                        throw new NotSupportedException($"Unrecognized export kind {kind}.");
-                                }
-                            }
-
-                            exportedFunctions = xFunctions.ToArray();
-                        }
+                        exportedFunctions = Section_Export(reader, functionTable, exportsBuilder, emptyTypes, memory, globals);
                         break;
 
                     case Section.Start:
-                        {
-                            if (internalFunctions == null)
-                                throw new ModuleLoadException("Start section created without any functions.", preSectionOffset);
-
-                            var preReadOffset = reader.Offset;
-                            var startIndex = reader.ReadVarInt32();
-                            if (startIndex >= internalFunctions.Length)
-                                throw new ModuleLoadException($"Start function of index {startIndex} exceeds available functions of {internalFunctions.Length}", preReadOffset);
-
-                            startFunction = internalFunctions[startIndex];
-                        }
+                        if (internalFunctions == null)
+                            throw new ModuleLoadException("Start section created without any functions.", preSectionOffset);
+                        startFunction = Section_Start(reader, internalFunctions);
                         break;
 
                     case Section.Element:
-                        {
-                            if (functionTable == null)
-                                throw new ModuleLoadException("Element section found without an associated table section or import.", preSectionOffset);
-
-                            // Holds the function table index of where an exsting function index has been mapped, for re-use.
-                            var existingDelegates = new Dictionary<uint, uint>();
-
-                            var count = reader.ReadVarUInt32();
-
-                            if (count == 0)
-                                break;
-
-                            var localFunctionTable = instanceConstructorIL.DeclareLocal(typeof(FunctionTable));
-                            instanceConstructorIL.EmitLoadArg(0);
-                            instanceConstructorIL.Emit(OpCodes.Ldfld, functionTable);
-                            instanceConstructorIL.Emit(OpCodes.Stloc, localFunctionTable);
-
-                            var getter = FunctionTable.IndexGetter;
-                            var setter = FunctionTable.IndexSetter;
-
-                            for (var i = 0; i < count; i++)
-                            {
-                                var preIndexOffset = reader.Offset;
-                                var index = reader.ReadVarUInt32();
-                                if (index != 0)
-                                    throw new ModuleLoadException($"Index value of anything other than 0 is not supported, {index} found.", preIndexOffset);
-
-                                uint offset;
-                                {
-                                    var preInitializerOffset = reader.Offset;
-                                    var initializer = Instruction.ParseInitializerExpression(reader).ToArray();
-                                    if (initializer.Length != 2 || initializer[0] is not Instructions.Int32Constant c || !(initializer[1] is Instructions.End))
-                                        throw new ModuleLoadException("Initializer expression support for the Element section is limited to a single Int32 constant followed by end.", preInitializerOffset);
-
-                                    offset = (uint)c.Value;
-                                }
-
-                                var preElementOffset = reader.Offset;
-                                var elements = reader.ReadVarUInt32();
-
-                                if (elements == 0)
-                                    continue;
-
-                                if (functionSignatures == null || internalFunctions == null)
-                                    throw new ModuleLoadException("Element section must be empty if there are no functions to reference.", preElementOffset);
-
-                                var isBigEnough = instanceConstructorIL.DefineLabel();
-                                instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
-                                instanceConstructorIL.Emit(OpCodes.Call, FunctionTable.LengthGetter);
-                                instanceConstructorIL.EmitLoadConstant(checked(offset + elements));
-                                instanceConstructorIL.Emit(OpCodes.Bge_Un, isBigEnough);
-
-                                instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
-                                instanceConstructorIL.EmitLoadConstant(checked(offset + elements));
-                                instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
-                                instanceConstructorIL.Emit(OpCodes.Call, FunctionTable.LengthGetter);
-                                instanceConstructorIL.Emit(OpCodes.Sub);
-                                instanceConstructorIL.Emit(OpCodes.Call, FunctionTable.GrowMethod);
-                                instanceConstructorIL.Emit(OpCodes.Pop);
-
-                                instanceConstructorIL.MarkLabel(isBigEnough);
-
-                                for (var j = 0u; j < elements; j++)
-                                {
-                                    var functionIndex = reader.ReadVarUInt32();
-                                    var signature = functionSignatures[functionIndex];
-                                    var parms = signature.ParameterTypes;
-                                    var returns = signature.ReturnTypes;
-
-                                    if (!delegateInvokersByTypeIndex.TryGetValue(signature.TypeIndex, out var invoker))
-                                    {
-                                        var del = configuration.GetDelegateForType(parms.Length, returns.Length);
-
-                                        if (del == null)
-                                            throw new CompilerException($"Failed to get a delegate for type {signature}.");
-
-                                        if (del.IsGenericType)
-                                            del = del.MakeGenericType(parms.Concat(returns).ToArray());
-
-                                        delegateInvokersByTypeIndex.Add(signature.TypeIndex, invoker = del.GetTypeInfo().GetDeclaredMethod(nameof(Action.Invoke))!);
-                                    }
-
-                                    instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
-                                    instanceConstructorIL.EmitLoadConstant(offset + j);
-
-                                    if (existingDelegates.TryGetValue(functionIndex, out var existing))
-                                    {
-                                        instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
-                                        instanceConstructorIL.EmitLoadConstant(existing);
-                                        instanceConstructorIL.Emit(OpCodes.Call, getter);
-                                    }
-                                    else
-                                    {
-                                        existingDelegates.Add(functionIndex, offset + j);
-
-                                        var wrapper = exportsBuilder.DefineMethod(
-                                            $"📦 {functionIndex}",
-                                            MethodAttributes.Private | MethodAttributes.HideBySig,
-                                            returns.Length == 0 ? typeof(void) : returns[0],
-                                            parms
-                                            );
-
-                                        var il = wrapper.GetILGenerator();
-                                        for (var k = 0; k < parms.Length; k++)
-                                            il.EmitLoadArg(k + 1);
-                                        il.EmitLoadArg(0);
-                                        il.Emit(OpCodes.Call, internalFunctions[functionIndex]);
-                                        il.Emit(OpCodes.Ret);
-
-                                        instanceConstructorIL.EmitLoadArg(0);
-                                        instanceConstructorIL.Emit(OpCodes.Ldftn, wrapper);
-                                        instanceConstructorIL.Emit(OpCodes.Newobj, invoker.DeclaringType!.GetTypeInfo().DeclaredConstructors.Single());
-                                    }
-
-                                    instanceConstructorIL.Emit(OpCodes.Call, setter);
-                                }
-                            }
-                        }
+                        if (functionTable == null)
+                            throw new ModuleLoadException("Element section found without an associated table section or import.", preSectionOffset);
+                        Section_Element(reader, functionTable, instanceConstructorIL, functionSignatures, internalFunctions, delegateInvokersByTypeIndex, configuration, exportsBuilder);
                         break;
 
                     case Section.Code:
-                        {
-                            if (functionSignatures == null)
-                                throw new InvalidOperationException();
-                            if (internalFunctions == null)
-                                throw new InvalidOperationException();
-
-                            var preBodiesIndex = reader.Offset;
-                            var functionBodies = reader.ReadVarUInt32();
-
-                            if (functionBodies > 0 && (functionSignatures == null || functionSignatures.Length == importedFunctions))
-                                throw new ModuleLoadException("Code section is invalid when Function section is missing.", preBodiesIndex);
-                            if (functionBodies != functionSignatures.Length - importedFunctions)
-                                throw new ModuleLoadException($"Code section has {functionBodies} functions described but {functionSignatures.Length - importedFunctions} were expected.", preBodiesIndex);
-
-                            for (var functionBodyIndex = 0; functionBodyIndex < functionBodies; functionBodyIndex++)
-                            {
-                                var signature = functionSignatures[importedFunctions + functionBodyIndex];
-                                var byteLength = reader.ReadVarUInt32();
-                                var startingOffset = reader.Offset;
-
-                                var locals = new Local[reader.ReadVarUInt32()];
-                                for (var localIndex = 0; localIndex < locals.Length; localIndex++)
-                                    locals[localIndex] = new Local(reader);
-
-                                var il = ((MethodBuilder)internalFunctions[importedFunctions + functionBodyIndex]).GetILGenerator();
-
-                                context.Reset(
-                                    il,
-                                    signature,
-                                    signature.RawParameterTypes.Concat(
-                                        locals
-                                        .SelectMany(local => Enumerable.Range(0, checked((int)local.Count)).Select(_ => local.Type))
-                                        ).ToArray()
-                                    );
-
-                                foreach (var local in locals.SelectMany(local => Enumerable.Range(0, checked((int)local.Count)).Select(_ => local.Type)))
-                                {
-                                    il.DeclareLocal(local.ToSystemType());
-                                }
-
-                                foreach (var instruction in Instruction.Parse(reader))
-                                {
-                                    instruction.Compile(context);
-                                    context.Previous = instruction.OpCode;
-                                }
-
-                                if (reader.Offset - startingOffset != byteLength)
-                                    throw new ModuleLoadException($"Instruction sequence reader ended after readering {reader.Offset - startingOffset} characters, expected {byteLength}.", reader.Offset);
-                            }
-                        }
+                        if (functionSignatures == null)
+                            throw new InvalidOperationException($"Code section found but {nameof(functionSignatures)} is null");
+                        if (internalFunctions == null)
+                            throw new InvalidOperationException($"Code section found but {nameof(internalFunctions)} is null");
+                        Section_Code(reader, context, functionSignatures, internalFunctions, importedFunctions);
                         break;
 
                     case Section.Data:
-                        {
-                            if (memory == null)
-                                throw new ModuleLoadException("Data section cannot be used unless a memory section is defined.", preSectionOffset);
-
-                            var count = reader.ReadVarUInt32();
-
-                            context.Reset(
-                                instanceConstructorIL,
-                                Signature.Empty,
-                                Signature.Empty.RawParameterTypes
-                                );
-                            var block = new Instructions.Block(BlockType.Int32);
-
-                            var address = instanceConstructorIL.DeclareLocal(typeof(uint));
-
-                            for (var i = 0; i < count; i++)
-                            {
-                                var startingOffset = reader.Offset;
-                                {
-                                    var index = reader.ReadVarUInt32();
-                                    if (index != 0)
-                                        throw new ModuleLoadException($"Data index must be 0, found {index}.", startingOffset);
-                                }
-
-                                block.Compile(context); //Prevents "end" instruction of the initializer expression from becoming a return.
-                                foreach (var instruction in Instruction.ParseInitializerExpression(reader))
-                                {
-                                    instruction.Compile(context);
-                                    context.Previous = instruction.OpCode;
-                                }
-                                context.Stack.Pop();
-                                context.BlockContexts.Remove(context.Depth.Count);
-                                instanceConstructorIL.Emit(OpCodes.Stloc, address);
-
-                                var data = reader.ReadBytes(reader.ReadVarUInt32());
-
-                                if (data.Length == 0)
-                                    continue;
-
-                                //Ensure sufficient memory is allocated, error if max is exceeded.
-                                instanceConstructorIL.Emit(OpCodes.Ldloc, address);
-                                instanceConstructorIL.Emit(OpCodes.Ldc_I4, data.Length);
-                                instanceConstructorIL.Emit(OpCodes.Add_Ovf_Un);
-
-                                instanceConstructorIL.Emit(OpCodes.Ldarg_0);
-
-                                instanceConstructorIL.Emit(OpCodes.Call, context[HelperMethod.RangeCheck8, Instructions.MemoryImmediateInstruction.CreateRangeCheck]);
-                                instanceConstructorIL.Emit(OpCodes.Pop);
-
-                                if (data.Length > 0x3f0000) //Limitation of DefineInitializedData, can be corrected by splitting the data.
-                                    throw new NotSupportedException($"Data segment {i} is length {data.Length}, exceeding the current implementation limit of 4128768.");
-
-                                var field = exportsBuilder.DefineInitializedData($"☣ Data {i}", data, FieldAttributes.Assembly | FieldAttributes.InitOnly);
-
-                                instanceConstructorIL.Emit(OpCodes.Ldarg_0);
-                                instanceConstructorIL.Emit(OpCodes.Ldfld, memory);
-                                instanceConstructorIL.Emit(OpCodes.Call, UnmanagedMemory.StartGetter);
-                                instanceConstructorIL.Emit(OpCodes.Ldloc, address);
-                                instanceConstructorIL.Emit(OpCodes.Conv_I);
-                                instanceConstructorIL.Emit(OpCodes.Add_Ovf_Un);
-
-                                instanceConstructorIL.Emit(OpCodes.Ldsflda, field);
-
-                                instanceConstructorIL.Emit(OpCodes.Ldc_I4, data.Length);
-
-                                instanceConstructorIL.Emit(OpCodes.Cpblk);
-                            }
-                        }
+                        if (memory == null)
+                            throw new ModuleLoadException("Data section cannot be used unless a memory section is defined.", preSectionOffset);
+                        Section_Data(reader, context, memory, instanceConstructorIL, exportsBuilder);
                         break;
 
                     default:
@@ -1279,6 +831,470 @@ namespace WebAssembly.Runtime
 
             module.CreateGlobalFunctions();
             return instance.DeclaredConstructors.First();
+        }
+
+        static GlobalInfo[] Section_Global(Reader reader, CompilationContext context, GlobalInfo[]? globals, TypeBuilder exportsBuilder, TypeBuilder exports, ILGenerator instanceConstructorIL, int importedGlobals)
+        {
+            var count = reader.ReadVarUInt32();
+            if (globals != null)
+            {
+                Array.Resize(ref globals, checked((int)(globals.Length + count)));
+                context.Globals = globals;
+            }
+            else
+            {
+                globals = context.Globals = new GlobalInfo[count];
+            }
+
+            var emptySignature = Signature.Empty;
+
+            for (var i = 0; i < count; i++)
+            {
+                var contentType = (WebAssemblyValueType)reader.ReadVarInt7();
+                var isMutable = reader.ReadVarUInt1() == 1;
+
+                var getter = exportsBuilder.DefineMethod(
+                    $"🌍 Get {i}",
+                    internalFunctionAttributes,
+                    CallingConventions.Standard,
+                    contentType.ToSystemType(),
+                    isMutable ? new Type[] { exports } : null
+                    );
+
+                var il = getter.GetILGenerator();
+                var getterSignature = new Signature(contentType);
+                MethodBuilder? setter;
+
+                if (isMutable == false)
+                {
+                    context.Reset(
+                        il,
+                        getterSignature,
+                        getterSignature.RawParameterTypes
+                        );
+
+                    foreach (var instruction in Instruction.ParseInitializerExpression(reader))
+                    {
+                        instruction.Compile(context);
+                        context.Previous = instruction.OpCode;
+                    }
+
+                    setter = null;
+                }
+                else //Mutable
+                {
+                    var field = exportsBuilder.DefineField(
+                        $"🌍 {i}",
+                        contentType.ToSystemType(),
+                        FieldAttributes.Private | (isMutable ? 0 : FieldAttributes.InitOnly)
+                        );
+
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, field);
+                    il.Emit(OpCodes.Ret);
+
+                    setter = exportsBuilder.DefineMethod(
+                    $"🌍 Set {i}",
+                        internalFunctionAttributes,
+                        CallingConventions.Standard,
+                        typeof(void),
+                        new[] { contentType.ToSystemType(), exports }
+                        );
+
+                    il = setter.GetILGenerator();
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Stfld, field);
+                    il.Emit(OpCodes.Ret);
+
+                    context.Reset(
+                        instanceConstructorIL,
+                        emptySignature,
+                        emptySignature.RawParameterTypes
+                        );
+
+                    context.EmitLoadThis();
+                    var ended = false;
+
+                    foreach (var instruction in Instruction.ParseInitializerExpression(reader))
+                    {
+                        if (ended)
+                            throw new CompilerException("Only a single End is allowed within an initializer expression.");
+
+                        if (instruction.OpCode == OpCode.End)
+                        {
+                            context.Emit(OpCodes.Stfld, field);
+                            ended = true;
+                            continue;
+                        }
+
+                        instruction.Compile(context);
+                        context.Previous = instruction.OpCode;
+                    }
+                }
+
+                globals[importedGlobals + i] = new GlobalInfo(contentType, isMutable, getter, setter);
+            }
+
+            return globals;
+        }
+
+        static KeyValuePair<string, uint>[] Section_Export(Reader reader, FieldBuilder? functionTable, TypeBuilder exportsBuilder, Type[] emptyTypes, FieldBuilder? memory, GlobalInfo[]? globals)
+        {
+            const MethodAttributes exportedPropertyAttributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.Virtual | MethodAttributes.Final;
+            var totalExports = reader.ReadVarUInt32();
+            var xFunctions = new List<KeyValuePair<string, uint>>((int)Math.Min(int.MaxValue, totalExports));
+
+            for (var i = 0; i < totalExports; i++)
+            {
+                var name = reader.ReadString(reader.ReadVarUInt32());
+                var preKindOffset = reader.Offset;
+                var kind = (ExternalKind)reader.ReadByte();
+                var preIndexOffset = reader.Offset;
+                var index = reader.ReadVarUInt32();
+                switch (kind)
+                {
+                    case ExternalKind.Function:
+                        xFunctions.Add(new KeyValuePair<string, uint>(name, index));
+                        break;
+                    case ExternalKind.Table:
+                        if (index != 0)
+                            throw new ModuleLoadException($"Exported table must be of index 0, found {index}.", preIndexOffset);
+                        if (functionTable == null)
+                            throw new ModuleLoadException("Can't export a table without defining or importing one.", preKindOffset);
+
+                        {
+                            var tableGetter = exportsBuilder.DefineMethod("get_" + name,
+                                exportedPropertyAttributes,
+                                CallingConventions.HasThis,
+                                typeof(FunctionTable),
+                                emptyTypes
+                                );
+                            tableGetter.SetCustomAttribute(NativeExportAttribute.Emit(ExternalKind.Table, name));
+                            var getterIL = tableGetter.GetILGenerator();
+                            getterIL.Emit(OpCodes.Ldarg_0);
+                            getterIL.Emit(OpCodes.Ldfld, functionTable);
+                            getterIL.Emit(OpCodes.Ret);
+
+                            exportsBuilder.DefineProperty(name, PropertyAttributes.None, typeof(FunctionTable), emptyTypes)
+                                .SetGetMethod(tableGetter);
+                        }
+                        break;
+                    case ExternalKind.Memory:
+                        if (index != 0)
+                            throw new ModuleLoadException($"Exported memory must be of index 0, found {index}.", preIndexOffset);
+                        if (memory == null)
+                            throw new CompilerException("Cannot export linear memory when linear memory is not defined.");
+
+                        {
+                            var memoryGetter = exportsBuilder.DefineMethod("get_" + name,
+                                exportedPropertyAttributes,
+                                CallingConventions.HasThis,
+                                typeof(UnmanagedMemory),
+                                emptyTypes
+                                );
+                            memoryGetter.SetCustomAttribute(NativeExportAttribute.Emit(ExternalKind.Memory, name));
+                            var getterIL = memoryGetter.GetILGenerator();
+                            getterIL.Emit(OpCodes.Ldarg_0);
+                            getterIL.Emit(OpCodes.Ldfld, memory);
+                            getterIL.Emit(OpCodes.Ret);
+
+                            exportsBuilder.DefineProperty(name, PropertyAttributes.None, typeof(UnmanagedMemory), emptyTypes)
+                                .SetGetMethod(memoryGetter);
+                        }
+                        break;
+                    case ExternalKind.Global:
+                        if (globals == null)
+                            throw new ModuleLoadException($"Exported index {index} is global but no globals are defined.", preIndexOffset);
+                        if (index >= globals.Length)
+                            throw new ModuleLoadException($"Exported global index of {index} is greater than the number of globals {globals.Length}.", preIndexOffset);
+
+                        {
+                            var global = globals[index];
+                            var property = exportsBuilder.DefineProperty(name, PropertyAttributes.None, global.Type.ToSystemType(), emptyTypes);
+                            property.SetCustomAttribute(NativeExportAttribute.Emit(ExternalKind.Global, name));
+                            var wrappedGet = exportsBuilder.DefineMethod("get_" + name,
+                                exportedPropertyAttributes,
+                                CallingConventions.HasThis,
+                                global.Type.ToSystemType(),
+                                emptyTypes
+                                );
+
+                            var wrappedGetIL = wrappedGet.GetILGenerator();
+                            if (global.RequiresInstance)
+                                wrappedGetIL.Emit(OpCodes.Ldarg_0);
+                            wrappedGetIL.Emit(OpCodes.Call, global.Getter);
+                            wrappedGetIL.Emit(OpCodes.Ret);
+                            property.SetGetMethod(wrappedGet);
+
+                            var setter = global.Setter;
+                            if (setter != null)
+                            {
+                                var wrappedSet = exportsBuilder.DefineMethod("set_" + name,
+                                    exportedPropertyAttributes,
+                                    CallingConventions.HasThis,
+                                    null,
+                                    new[] { global.Type.ToSystemType() }
+                                    );
+
+                                var wrappedSetIL = wrappedSet.GetILGenerator();
+                                wrappedSetIL.Emit(OpCodes.Ldarg_1);
+                                if (global.RequiresInstance)
+                                    wrappedSetIL.Emit(OpCodes.Ldarg_0);
+                                wrappedSetIL.Emit(OpCodes.Call, setter);
+                                wrappedSetIL.Emit(OpCodes.Ret);
+
+                                property.SetSetMethod(wrappedSet);
+                            }
+                        }
+                        break;
+                    default:
+                        throw new NotSupportedException($"Unrecognized export kind {kind}.");
+                }
+            }
+
+            return xFunctions.ToArray();
+        }
+
+        static MethodInfo Section_Start(Reader reader, MethodInfo[] internalFunctions)
+        {
+            var preReadOffset = reader.Offset;
+            var startIndex = reader.ReadVarInt32();
+            if (startIndex >= internalFunctions.Length)
+                throw new ModuleLoadException($"Start function of index {startIndex} exceeds available functions of {internalFunctions.Length}", preReadOffset);
+
+            return internalFunctions[startIndex];
+        }
+
+        static void Section_Element(Reader reader, FieldBuilder functionTable, ILGenerator instanceConstructorIL, Signature[]? functionSignatures, MethodInfo[]? internalFunctions, Dictionary<uint, MethodInfo> delegateInvokersByTypeIndex, CompilerConfiguration configuration, TypeBuilder exportsBuilder)
+        {
+            // Holds the function table index of where an exsting function index has been mapped, for re-use.
+            var existingDelegates = new Dictionary<uint, uint>();
+
+            var count = reader.ReadVarUInt32();
+
+            if (count == 0)
+                return;
+
+            var localFunctionTable = instanceConstructorIL.DeclareLocal(typeof(FunctionTable));
+            instanceConstructorIL.EmitLoadArg(0);
+            instanceConstructorIL.Emit(OpCodes.Ldfld, functionTable);
+            instanceConstructorIL.Emit(OpCodes.Stloc, localFunctionTable);
+
+            var getter = FunctionTable.IndexGetter;
+            var setter = FunctionTable.IndexSetter;
+
+            for (var i = 0; i < count; i++)
+            {
+                var preIndexOffset = reader.Offset;
+                var index = reader.ReadVarUInt32();
+                if (index != 0)
+                    throw new ModuleLoadException($"Index value of anything other than 0 is not supported, {index} found.", preIndexOffset);
+
+                uint offset;
+                {
+                    var preInitializerOffset = reader.Offset;
+                    var initializer = Instruction.ParseInitializerExpression(reader).ToArray();
+                    if (initializer.Length != 2 || initializer[0] is not Instructions.Int32Constant c || !(initializer[1] is Instructions.End))
+                        throw new ModuleLoadException("Initializer expression support for the Element section is limited to a single Int32 constant followed by end.", preInitializerOffset);
+
+                    offset = (uint)c.Value;
+                }
+
+                var preElementOffset = reader.Offset;
+                var elements = reader.ReadVarUInt32();
+
+                if (elements == 0)
+                    continue;
+
+                if (functionSignatures == null || internalFunctions == null)
+                    throw new ModuleLoadException("Element section must be empty if there are no functions to reference.", preElementOffset);
+
+                var isBigEnough = instanceConstructorIL.DefineLabel();
+                instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
+                instanceConstructorIL.Emit(OpCodes.Call, FunctionTable.LengthGetter);
+                instanceConstructorIL.EmitLoadConstant(checked(offset + elements));
+                instanceConstructorIL.Emit(OpCodes.Bge_Un, isBigEnough);
+
+                instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
+                instanceConstructorIL.EmitLoadConstant(checked(offset + elements));
+                instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
+                instanceConstructorIL.Emit(OpCodes.Call, FunctionTable.LengthGetter);
+                instanceConstructorIL.Emit(OpCodes.Sub);
+                instanceConstructorIL.Emit(OpCodes.Call, FunctionTable.GrowMethod);
+                instanceConstructorIL.Emit(OpCodes.Pop);
+
+                instanceConstructorIL.MarkLabel(isBigEnough);
+
+                for (var j = 0u; j < elements; j++)
+                {
+                    var functionIndex = reader.ReadVarUInt32();
+                    var signature = functionSignatures[functionIndex];
+                    var parms = signature.ParameterTypes;
+                    var returns = signature.ReturnTypes;
+
+                    if (!delegateInvokersByTypeIndex.TryGetValue(signature.TypeIndex, out var invoker))
+                    {
+                        var del = configuration.GetDelegateForType(parms.Length, returns.Length);
+
+                        if (del == null)
+                            throw new CompilerException($"Failed to get a delegate for type {signature}.");
+
+                        if (del.IsGenericType)
+                            del = del.MakeGenericType(parms.Concat(returns).ToArray());
+
+                        delegateInvokersByTypeIndex.Add(signature.TypeIndex, invoker = del.GetTypeInfo().GetDeclaredMethod(nameof(Action.Invoke))!);
+                    }
+
+                    instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
+                    instanceConstructorIL.EmitLoadConstant(offset + j);
+
+                    if (existingDelegates.TryGetValue(functionIndex, out var existing))
+                    {
+                        instanceConstructorIL.Emit(OpCodes.Ldloc, localFunctionTable);
+                        instanceConstructorIL.EmitLoadConstant(existing);
+                        instanceConstructorIL.Emit(OpCodes.Call, getter);
+                    }
+                    else
+                    {
+                        existingDelegates.Add(functionIndex, offset + j);
+
+                        var wrapper = exportsBuilder.DefineMethod(
+                            $"📦 {functionIndex}",
+                            MethodAttributes.Private | MethodAttributes.HideBySig,
+                            returns.Length == 0 ? typeof(void) : returns[0],
+                            parms
+                            );
+
+                        var il = wrapper.GetILGenerator();
+                        for (var k = 0; k < parms.Length; k++)
+                            il.EmitLoadArg(k + 1);
+                        il.EmitLoadArg(0);
+                        il.Emit(OpCodes.Call, internalFunctions[functionIndex]);
+                        il.Emit(OpCodes.Ret);
+
+                        instanceConstructorIL.EmitLoadArg(0);
+                        instanceConstructorIL.Emit(OpCodes.Ldftn, wrapper);
+                        instanceConstructorIL.Emit(OpCodes.Newobj, invoker.DeclaringType!.GetTypeInfo().DeclaredConstructors.Single());
+                    }
+
+                    instanceConstructorIL.Emit(OpCodes.Call, setter);
+                }
+            }
+        }
+
+        static void Section_Code(Reader reader, CompilationContext context, Signature[] functionSignatures, MethodInfo[] internalFunctions, int importedFunctions)
+        {
+            var preBodiesIndex = reader.Offset;
+            var functionBodies = reader.ReadVarUInt32();
+
+            if (functionBodies > 0 && (functionSignatures == null || functionSignatures.Length == importedFunctions))
+                throw new ModuleLoadException("Code section is invalid when Function section is missing.", preBodiesIndex);
+            if (functionBodies != functionSignatures.Length - importedFunctions)
+                throw new ModuleLoadException($"Code section has {functionBodies} functions described but {functionSignatures.Length - importedFunctions} were expected.", preBodiesIndex);
+
+            for (var functionBodyIndex = 0; functionBodyIndex < functionBodies; functionBodyIndex++)
+            {
+                var signature = functionSignatures[importedFunctions + functionBodyIndex];
+                var byteLength = reader.ReadVarUInt32();
+                var startingOffset = reader.Offset;
+
+                var locals = new Local[reader.ReadVarUInt32()];
+                for (var localIndex = 0; localIndex < locals.Length; localIndex++)
+                    locals[localIndex] = new Local(reader);
+
+                var il = ((MethodBuilder)internalFunctions[importedFunctions + functionBodyIndex]).GetILGenerator();
+
+                context.Reset(
+                    il,
+                    signature,
+                    signature.RawParameterTypes.Concat(
+                        locals
+                        .SelectMany(local => Enumerable.Range(0, checked((int)local.Count)).Select(_ => local.Type))
+                        ).ToArray()
+                    );
+
+                foreach (var local in locals.SelectMany(local => Enumerable.Range(0, checked((int)local.Count)).Select(_ => local.Type)))
+                {
+                    il.DeclareLocal(local.ToSystemType());
+                }
+
+                foreach (var instruction in Instruction.Parse(reader))
+                {
+                    instruction.Compile(context);
+                    context.Previous = instruction.OpCode;
+                }
+
+                if (reader.Offset - startingOffset != byteLength)
+                    throw new ModuleLoadException($"Instruction sequence reader ended after readering {reader.Offset - startingOffset} characters, expected {byteLength}.", reader.Offset);
+            }
+        }
+
+        static void Section_Data(Reader reader, CompilationContext context, FieldBuilder memory, ILGenerator instanceConstructorIL, TypeBuilder exportsBuilder)
+        {
+            var count = reader.ReadVarUInt32();
+
+            context.Reset(
+                instanceConstructorIL,
+                Signature.Empty,
+                Signature.Empty.RawParameterTypes
+                );
+            var block = new Instructions.Block(BlockType.Int32);
+
+            var address = instanceConstructorIL.DeclareLocal(typeof(uint));
+
+            for (var i = 0; i < count; i++)
+            {
+                var startingOffset = reader.Offset;
+                {
+                    var index = reader.ReadVarUInt32();
+                    if (index != 0)
+                        throw new ModuleLoadException($"Data index must be 0, found {index}.", startingOffset);
+                }
+
+                block.Compile(context); //Prevents "end" instruction of the initializer expression from becoming a return.
+                foreach (var instruction in Instruction.ParseInitializerExpression(reader))
+                {
+                    instruction.Compile(context);
+                    context.Previous = instruction.OpCode;
+                }
+                context.Stack.Pop();
+                context.BlockContexts.Remove(context.Depth.Count);
+                instanceConstructorIL.Emit(OpCodes.Stloc, address);
+
+                var data = reader.ReadBytes(reader.ReadVarUInt32());
+
+                if (data.Length == 0)
+                    continue;
+
+                //Ensure sufficient memory is allocated, error if max is exceeded.
+                instanceConstructorIL.Emit(OpCodes.Ldloc, address);
+                instanceConstructorIL.Emit(OpCodes.Ldc_I4, data.Length);
+                instanceConstructorIL.Emit(OpCodes.Add_Ovf_Un);
+
+                instanceConstructorIL.Emit(OpCodes.Ldarg_0);
+
+                instanceConstructorIL.Emit(OpCodes.Call, context[HelperMethod.RangeCheck8, Instructions.MemoryImmediateInstruction.CreateRangeCheck]);
+                instanceConstructorIL.Emit(OpCodes.Pop);
+
+                if (data.Length > 0x3f0000) //Limitation of DefineInitializedData, can be corrected by splitting the data.
+                    throw new NotSupportedException($"Data segment {i} is length {data.Length}, exceeding the current implementation limit of 4128768.");
+
+                var field = exportsBuilder.DefineInitializedData($"☣ Data {i}", data, FieldAttributes.Assembly | FieldAttributes.InitOnly);
+
+                instanceConstructorIL.Emit(OpCodes.Ldarg_0);
+                instanceConstructorIL.Emit(OpCodes.Ldfld, memory);
+                instanceConstructorIL.Emit(OpCodes.Call, UnmanagedMemory.StartGetter);
+                instanceConstructorIL.Emit(OpCodes.Ldloc, address);
+                instanceConstructorIL.Emit(OpCodes.Conv_I);
+                instanceConstructorIL.Emit(OpCodes.Add_Ovf_Un);
+
+                instanceConstructorIL.Emit(OpCodes.Ldsflda, field);
+
+                instanceConstructorIL.Emit(OpCodes.Ldc_I4, data.Length);
+
+                instanceConstructorIL.Emit(OpCodes.Cpblk);
+            }
         }
 
         static FieldBuilder CreateFunctionTableField(TypeBuilder exportsBuilder)


### PR DESCRIPTION
This change is intended to work toward one of the current development objectives:
- Improve exceptions thrown from problems found during compilation or execution.

For issue #35, this would have resulted in the following additional line
in the stack trace:
`   at WebAssembly.Runtime.Compile.Section_Global(...)`

If this change is deemed desirable, I'd like to make similar changes to
the remaining section cases. Some of them will present the challenge of
multiple local variable mutations (e.g. Section.Memory) which I would
intend to solve with multiple return values.

Note: I also promoted the `TypeAttributes` local constants (e.g.
`internalFunctionAttributes`) to member constants because they'll need
to be referenced in the methods that will be factored out and there's no
need to pass them as parameters since they're constant.

@RyanLamansky I hope you don't mind I wanted to take a stab at one of the (easier) development objectives and improve the stack traces in particular for issue #35. This is a simple technique we've used at my job to improve stack traces for large methods. If you deem this technique to have issues, no sweat -- please let me know if there's a better method you'd recommend!