### PR TITLE
Improve `FromBinary` stack traces, part 2

### DIFF
--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -255,7 +255,6 @@ namespace WebAssembly.Runtime
                 }
             }
 
-            var exports = exportsBuilder;
             var importedFunctions = 0;
             var importedGlobals = 0;
             MethodInfo[]? internalFunctions = null;
@@ -335,7 +334,7 @@ namespace WebAssembly.Runtime
                                                 InternalFunctionAttributes,
                                                 CallingConventions.Standard,
                                                 signature.ReturnTypes.Length != 0 ? signature.ReturnTypes[0] : null,
-                                                signature.ParameterTypes.Concat(new Type[] { exports }).ToArray()
+                                                signature.ParameterTypes.Concat(new Type[] { exportsBuilder }).ToArray()
                                                 );
 
                                             var invokerIL = invoker.GetILGenerator();
@@ -411,7 +410,7 @@ namespace WebAssembly.Runtime
                                                 InternalFunctionAttributes,
                                                 CallingConventions.Standard,
                                                 typeof(UnmanagedMemory),
-                                                new Type[] { exports }
+                                                new Type[] { exportsBuilder }
                                                 );
 
                                             var invokerIL = importedMemoryProvider.GetILGenerator();
@@ -460,7 +459,7 @@ namespace WebAssembly.Runtime
                                                 InternalFunctionAttributes,
                                                 CallingConventions.Standard,
                                                 contentType.ToSystemType(),
-                                                new Type[] { exports }
+                                                new Type[] { exportsBuilder }
                                                 );
 
                                             var invokerIL = getterInvoker.GetILGenerator();
@@ -503,7 +502,7 @@ namespace WebAssembly.Runtime
                                                 InternalFunctionAttributes,
                                                 CallingConventions.Standard,
                                                 null,
-                                                new[] { contentType.ToSystemType(), exports }
+                                                new[] { contentType.ToSystemType(), exportsBuilder }
                                                 );
 
                                                 invokerIL = setterInvoker.GetILGenerator();
@@ -581,7 +580,7 @@ namespace WebAssembly.Runtime
                             for (var i = importedFunctionCount; i < functionSignatures.Length; i++)
                             {
                                 var signature = functionSignatures[i] = signatures[reader.ReadVarUInt32()];
-                                var parms = signature.ParameterTypes.Concat(new Type[] { exports }).ToArray();
+                                var parms = signature.ParameterTypes.Concat(new Type[] { exportsBuilder }).ToArray();
                                 internalFunctions[i] = exportsBuilder.DefineMethod(
                                     $"👻 {i}",
                                     InternalFunctionAttributes,
@@ -716,7 +715,7 @@ namespace WebAssembly.Runtime
                         break;
 
                     case Section.Global:
-                        globals = SectionGlobal(reader, context, globals, exportsBuilder, exports, instanceConstructorIL, importedGlobals);
+                        globals = SectionGlobal(reader, context, globals, exportsBuilder, instanceConstructorIL, importedGlobals);
                         break;
 
                     case Section.Export:
@@ -828,7 +827,7 @@ namespace WebAssembly.Runtime
             return instance.DeclaredConstructors.First();
         }
 
-        static GlobalInfo[] SectionGlobal(Reader reader, CompilationContext context, GlobalInfo[]? globals, TypeBuilder exportsBuilder, TypeBuilder exports, ILGenerator instanceConstructorIL, int importedGlobals)
+        static GlobalInfo[] SectionGlobal(Reader reader, CompilationContext context, GlobalInfo[]? globals, TypeBuilder exportsBuilder, ILGenerator instanceConstructorIL, int importedGlobals)
         {
             var count = reader.ReadVarUInt32();
             if (globals != null)
@@ -853,7 +852,7 @@ namespace WebAssembly.Runtime
                     InternalFunctionAttributes,
                     CallingConventions.Standard,
                     contentType.ToSystemType(),
-                    isMutable ? new Type[] { exports } : null
+                    isMutable ? new Type[] { exportsBuilder } : null
                     );
 
                 var il = getter.GetILGenerator();
@@ -893,7 +892,7 @@ namespace WebAssembly.Runtime
                         InternalFunctionAttributes,
                         CallingConventions.Standard,
                         typeof(void),
-                        new[] { contentType.ToSystemType(), exports }
+                        new[] { contentType.ToSystemType(), exportsBuilder }
                         );
 
                     il = setter.GetILGenerator();

--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -237,11 +237,6 @@ namespace WebAssembly.Runtime
             MethodBuilder? importedMemoryProvider = null;
             FieldBuilder? memory = null;
 
-            void CreateMemoryField()
-            {
-                memory = context!.Memory = exportsBuilder!.DefineField("☣ Memory", typeof(UnmanagedMemory), PrivateReadonlyField);
-            }
-
             ILGenerator instanceConstructorIL;
             {
                 var instanceConstructor = exportsBuilder.DefineConstructor(
@@ -444,7 +439,7 @@ namespace WebAssembly.Runtime
                                             ImportException.EmitTryCast(instanceConstructorIL, typedDelegate);
                                             instanceConstructorIL.Emit(OpCodes.Stfld, delFieldBuilder);
 
-                                            CreateMemoryField();
+                                            memory = context.Memory = CreateMemoryField(exportsBuilder);
                                             instanceConstructorIL.Emit(OpCodes.Ldarg_0);
                                             instanceConstructorIL.Emit(OpCodes.Ldarg_0);
                                             instanceConstructorIL.Emit(OpCodes.Call, importedMemoryProvider);
@@ -676,7 +671,7 @@ namespace WebAssembly.Runtime
                             else
                                 memoryPagesMaximum = uint.MaxValue / Memory.PageSize;
 
-                            CreateMemoryField();
+                            memory = context.Memory = CreateMemoryField(exportsBuilder);
 
                             instanceConstructorIL.Emit(OpCodes.Ldarg_0);
                             Instructions.Int32Constant.Emit(instanceConstructorIL, (int)memoryPagesMinimum);
@@ -1300,6 +1295,11 @@ namespace WebAssembly.Runtime
         static FieldBuilder CreateFunctionTableField(TypeBuilder exportsBuilder)
         {
             return exportsBuilder.DefineField("☣ FunctionTable", typeof(FunctionTable), FieldAttributes.Private | FieldAttributes.InitOnly);
+        }
+
+        static FieldBuilder CreateMemoryField(TypeBuilder exportsBuilder)
+        {
+            return exportsBuilder.DefineField("☣ Memory", typeof(UnmanagedMemory), PrivateReadonlyField);
         }
     }
 }


### PR DESCRIPTION
This is part 2 of a set of changes that are intended to work toward this development objective (part 1 was #37):
- Improve exceptions thrown from problems found during compilation or execution.

The first two commits are minor adjustments that will facilitate the intended refactoring.

The third commit is to factor out the `SectionImport` method. This should end up being the most difficult section, and I wanted to get input on this before I do the remaining ones, which should be rinse and repeat of the technique I used here. In addition to general review, I have a question about a further improvement I could make if you deem the idea acceptable:

Would it be acceptable to use the props of `CompilationContext` in `FromBinary` and remove the corresponding locals (e.g. use `context.FunctionSignatures` instead of `functionSignatures`)? If so, this would reduce the number of values I need to return from `SectionImport`, since I could rely on the mutation of the `CompilationContext` prop across the method call. However, if it is better to keep the locals in `FromBinary`, I would prefer returning all the values in the return type of `SectionImport` as I am doing because then the return type covers all of the values that need to be propagated into `FromBinary` and no one has to remember that they must also set such and such a local from such and such a prop of `CompilationContext` after calling `SectionImport`, which I think would be error prone.