### PR TITLE
Error improvements, part 1

### DIFF
--- a/WebAssembly.Tests/Instructions/LocalGetTests.cs
+++ b/WebAssembly.Tests/Instructions/LocalGetTests.cs
@@ -105,4 +105,18 @@ public class LocalGetTests
         Assert.AreEqual(9, compiled4.Test(12, 11, 10, 9));
         Assert.AreEqual(999, compiled4.Test(1002, 1001, 1000, 999));
     }
+
+    /// <summary>
+    /// Tests the error message when a local is referenced that isn't defined for the <see cref="LocalGet"/> instruction.
+    /// </summary>
+    [TestMethod]
+    public void GetLocal_Compiled_Parameter_OutOfRange()
+    {
+        var exception = Assert.ThrowsException<ModuleLoadException>(
+            () => AssemblyBuilder.CreateInstance<ParameterTest>("Test", WebAssemblyValueType.Int32, new[] { WebAssemblyValueType.Int32 },
+                new LocalGet(1),
+                new End()
+                ));
+        Assert.AreEqual("At offset 37: Attempt to get local at index 1 but only 1 local was defined.", exception.Message);
+    }
 }

--- a/WebAssembly.Tests/Instructions/LocalSetTests.cs
+++ b/WebAssembly.Tests/Instructions/LocalSetTests.cs
@@ -27,4 +27,19 @@ public class LocalSetTests
         Assert.AreEqual(2, exports.Test(0));
         Assert.AreEqual(3, exports.Test(1));
     }
+
+    /// <summary>
+    /// Tests the error message when a local is referenced that isn't defined for the <see cref="LocalSet"/> instruction.
+    /// </summary>
+    [TestMethod]
+    public void GetLocal_Compiled_Parameter_OutOfRange()
+    {
+        var exception = Assert.ThrowsException<ModuleLoadException>(
+            () => CompilerTestBase<int>.CreateInstance(
+                new Int32Constant(42),
+                new LocalSet(1),
+                new End()
+                ));
+        Assert.AreEqual("At offset 39: Attempt to set local at index 1 but only 1 local was defined.", exception.Message);
+    }
 }

--- a/WebAssembly/Instructions/Branch.cs
+++ b/WebAssembly/Instructions/Branch.cs
@@ -70,7 +70,7 @@ public class Branch : Instruction
     /// Provides a native representation of the instruction.
     /// </summary>
     /// <returns>A string representation of this instance.</returns>
-    public override string ToString() => $"{base.ToString()} {Index})";
+    public override string ToString() => $"{base.ToString()} {Index}";
 
     internal sealed override void Compile(CompilationContext context)
     {

--- a/WebAssembly/Instructions/BranchIf.cs
+++ b/WebAssembly/Instructions/BranchIf.cs
@@ -76,4 +76,10 @@ public class BranchIf : Instruction
 
         context.Emit(OpCodes.Brtrue, context.Labels[checked((uint)context.Depth.Count) - this.Index - 1]);
     }
+
+    /// <summary>
+    /// Provides a native representation of the instruction and the block index
+    /// </summary>
+    /// <returns>A string representation of this instance and the block index.</returns>
+    public override string ToString() => $"{base.ToString()} {Index}";
 }

--- a/WebAssembly/Instructions/LocalGet.cs
+++ b/WebAssembly/Instructions/LocalGet.cs
@@ -37,6 +37,8 @@ public class LocalGet : VariableAccessInstruction
 
     internal sealed override void Compile(CompilationContext context)
     {
+        if (this.Index >= context.CheckedLocals.Length)
+            throw new System.IndexOutOfRangeException($"Attempt to get local at index {this.Index} but only {context.CheckedLocals.Length} {(context.CheckedLocals.Length == 1 ? "local was" : "locals were")} defined.");
         context.Stack.Push(context.CheckedLocals[this.Index]);
 
         var localIndex = this.Index - context.CheckedSignature.ParameterTypes.Length;

--- a/WebAssembly/Instructions/LocalSet.cs
+++ b/WebAssembly/Instructions/LocalSet.cs
@@ -37,6 +37,8 @@ public class LocalSet : VariableAccessInstruction
 
     internal sealed override void Compile(CompilationContext context)
     {
+        if (this.Index >= context.CheckedLocals.Length)
+            throw new System.IndexOutOfRangeException($"Attempt to set local at index {this.Index} but only {context.CheckedLocals.Length} {(context.CheckedLocals.Length == 1 ? "local was" : "locals were")} defined.");
         context.PopStackNoReturn(OpCode.LocalSet, context.CheckedLocals[this.Index]);
 
         var localIndex = this.Index - context.CheckedSignature.ParameterTypes.Length;


### PR DESCRIPTION
@RyanLamansky Please let me know if these changes are more in line with what you're hoping from the development objective: "Improve exceptions thrown from problems found during compilation or execution." Do you think it would be worth going ahead and factoring out the remaining sections from `Compile.FromBinary`? I'm happy with whatever you decide -- part of me thinks it would be better to be consistent, but I don't feel strongly.

~~Note: My changes in ab473ee8330ee54fece20ec6d797218f9e37a1bc introduced test failures in `SpecTest_i32` and `SpecTest_i64` because `rotr`
wasn't defined on the `IntegerMath` class, so I defined it as it looks like all the other methods from the JSON files were expected to be defined on that class. I'm not entirely sure what's going on with those tests -- an explanation would be helpful so I understand.~~

Also, just FYI I've started working on an F# wrapper around your library as the ultimate project I'd like to use your library for will involve consuming it from F#: https://github.com/munik/dotnet-webassembly-fsharp. Let me know if you have any input!