### PR TITLE
Fix Rider errors

### DIFF
--- a/WebAssembly.Tests/MemoryWriteTestBase.cs
+++ b/WebAssembly.Tests/MemoryWriteTestBase.cs
@@ -60,6 +60,6 @@ where T : struct
             Code = instructions,
         });
 
-        return module.ToInstance<MemoryWriteTestBase<T>>(); ;
+        return module.ToInstance<MemoryWriteTestBase<T>>();
     }
 }

--- a/WebAssembly/FunctionBody.cs
+++ b/WebAssembly/FunctionBody.cs
@@ -128,7 +128,7 @@ public class FunctionBody : IEquatable<FunctionBody>
             }
 
             return !itemMoved && !othersMoved;
-        };
+        }
     }
 
     internal void WriteTo(Writer writer, byte[] buffer)

--- a/WebAssembly/Instructions/Block.cs
+++ b/WebAssembly/Instructions/Block.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Block : BlockTypeInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Block"/>.
+    /// Always <see cref="WebAssembly.OpCode.Block"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Block;
 

--- a/WebAssembly/Instructions/Branch.cs
+++ b/WebAssembly/Instructions/Branch.cs
@@ -11,7 +11,7 @@ namespace WebAssembly.Instructions;
 public class Branch : Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Branch"/>.
+    /// Always <see cref="WebAssembly.OpCode.Branch"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Branch;
 

--- a/WebAssembly/Instructions/BranchIf.cs
+++ b/WebAssembly/Instructions/BranchIf.cs
@@ -11,7 +11,7 @@ namespace WebAssembly.Instructions;
 public class BranchIf : Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.BranchIf"/>.
+    /// Always <see cref="WebAssembly.OpCode.BranchIf"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.BranchIf;
 

--- a/WebAssembly/Instructions/BranchTable.cs
+++ b/WebAssembly/Instructions/BranchTable.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class BranchTable : Instruction, IEquatable<BranchTable>
 {
     /// <summary>
-    /// Always <see cref="OpCode.BranchTable"/>.
+    /// Always <see cref="WebAssembly.OpCode.BranchTable"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.BranchTable;
 

--- a/WebAssembly/Instructions/Call.cs
+++ b/WebAssembly/Instructions/Call.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Instructions;
 public class Call : Instruction, IEquatable<Call>
 {
     /// <summary>
-    /// Always <see cref="OpCode.Call"/>.
+    /// Always <see cref="WebAssembly.OpCode.Call"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Call;
 

--- a/WebAssembly/Instructions/CallIndirect.cs
+++ b/WebAssembly/Instructions/CallIndirect.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class CallIndirect : Instruction, IEquatable<CallIndirect>
 {
     /// <summary>
-    /// Always <see cref="OpCode.CallIndirect"/>.
+    /// Always <see cref="WebAssembly.OpCode.CallIndirect"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.CallIndirect;
 

--- a/WebAssembly/Instructions/Drop.cs
+++ b/WebAssembly/Instructions/Drop.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Drop : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Drop"/>.
+    /// Always <see cref="WebAssembly.OpCode.Drop"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Drop;
 

--- a/WebAssembly/Instructions/Else.cs
+++ b/WebAssembly/Instructions/Else.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Else : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Else"/>.
+    /// Always <see cref="WebAssembly.OpCode.Else"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Else;
 

--- a/WebAssembly/Instructions/End.cs
+++ b/WebAssembly/Instructions/End.cs
@@ -11,7 +11,7 @@ namespace WebAssembly.Instructions;
 public class End : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.End"/>.
+    /// Always <see cref="WebAssembly.OpCode.End"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.End;
 

--- a/WebAssembly/Instructions/Float32Absolute.cs
+++ b/WebAssembly/Instructions/Float32Absolute.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float32Absolute : ValueOneToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Absolute"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Absolute"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Absolute;
 

--- a/WebAssembly/Instructions/Float32Add.cs
+++ b/WebAssembly/Instructions/Float32Add.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32Add : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Add"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Add"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Add;
 

--- a/WebAssembly/Instructions/Float32Ceiling.cs
+++ b/WebAssembly/Instructions/Float32Ceiling.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Float32Ceiling : Float64CallWrapperInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Ceiling"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Ceiling"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Ceiling;
 

--- a/WebAssembly/Instructions/Float32Constant.cs
+++ b/WebAssembly/Instructions/Float32Constant.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float32Constant : Constant<float>
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Constant"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Constant"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Constant;
 

--- a/WebAssembly/Instructions/Float32ConvertInt32Signed.cs
+++ b/WebAssembly/Instructions/Float32ConvertInt32Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float32ConvertInt32Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32ConvertInt32Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32ConvertInt32Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32ConvertInt32Signed;
 

--- a/WebAssembly/Instructions/Float32ConvertInt32Unsigned.cs
+++ b/WebAssembly/Instructions/Float32ConvertInt32Unsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float32ConvertInt32Unsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32ConvertInt32Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32ConvertInt32Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32ConvertInt32Unsigned;
 

--- a/WebAssembly/Instructions/Float32ConvertInt64Signed.cs
+++ b/WebAssembly/Instructions/Float32ConvertInt64Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float32ConvertInt64Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32ConvertInt64Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32ConvertInt64Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32ConvertInt64Signed;
 

--- a/WebAssembly/Instructions/Float32ConvertInt64Unsigned.cs
+++ b/WebAssembly/Instructions/Float32ConvertInt64Unsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float32ConvertInt64Unsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32ConvertInt64Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32ConvertInt64Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32ConvertInt64Unsigned;
 

--- a/WebAssembly/Instructions/Float32CopySign.cs
+++ b/WebAssembly/Instructions/Float32CopySign.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float32CopySign : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32CopySign"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32CopySign"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32CopySign;
 

--- a/WebAssembly/Instructions/Float32DemoteFloat64.cs
+++ b/WebAssembly/Instructions/Float32DemoteFloat64.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float32DemoteFloat64 : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32DemoteFloat64"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32DemoteFloat64"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32DemoteFloat64;
 

--- a/WebAssembly/Instructions/Float32Divide.cs
+++ b/WebAssembly/Instructions/Float32Divide.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32Divide : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Divide"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Divide"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Divide;
 

--- a/WebAssembly/Instructions/Float32Equal.cs
+++ b/WebAssembly/Instructions/Float32Equal.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32Equal : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Equal"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Equal"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Equal;
 

--- a/WebAssembly/Instructions/Float32Floor.cs
+++ b/WebAssembly/Instructions/Float32Floor.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Float32Floor : Float64CallWrapperInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Floor"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Floor"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Floor;
 

--- a/WebAssembly/Instructions/Float32GreaterThan.cs
+++ b/WebAssembly/Instructions/Float32GreaterThan.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32GreaterThan : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32GreaterThan"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32GreaterThan"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32GreaterThan;
 

--- a/WebAssembly/Instructions/Float32GreaterThanOrEqual.cs
+++ b/WebAssembly/Instructions/Float32GreaterThanOrEqual.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32GreaterThanOrEqual : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32GreaterThanOrEqual"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32GreaterThanOrEqual"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32GreaterThanOrEqual;
 

--- a/WebAssembly/Instructions/Float32LessThan.cs
+++ b/WebAssembly/Instructions/Float32LessThan.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32LessThan : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32LessThan"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32LessThan"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32LessThan;
 

--- a/WebAssembly/Instructions/Float32LessThanOrEqual.cs
+++ b/WebAssembly/Instructions/Float32LessThanOrEqual.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32LessThanOrEqual : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32LessThanOrEqual"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32LessThanOrEqual"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32LessThanOrEqual;
 

--- a/WebAssembly/Instructions/Float32Load.cs
+++ b/WebAssembly/Instructions/Float32Load.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Float32Load : MemoryReadInstruction, System.IEquatable<Float32Load>
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Load"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Load"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Load;
 

--- a/WebAssembly/Instructions/Float32Maximum.cs
+++ b/WebAssembly/Instructions/Float32Maximum.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float32Maximum : ValueTwoToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Maximum"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Maximum"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Maximum;
 

--- a/WebAssembly/Instructions/Float32Minimum.cs
+++ b/WebAssembly/Instructions/Float32Minimum.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float32Minimum : ValueTwoToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Minimum"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Minimum"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Minimum;
 

--- a/WebAssembly/Instructions/Float32Multiply.cs
+++ b/WebAssembly/Instructions/Float32Multiply.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32Multiply : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Multiply"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Multiply"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Multiply;
 

--- a/WebAssembly/Instructions/Float32Nearest.cs
+++ b/WebAssembly/Instructions/Float32Nearest.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Float32Nearest : Float64CallWrapperInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Nearest"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Nearest"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Nearest;
 

--- a/WebAssembly/Instructions/Float32Negate.cs
+++ b/WebAssembly/Instructions/Float32Negate.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Float32Negate : ValueOneToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Negate"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Negate"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Negate;
 

--- a/WebAssembly/Instructions/Float32NotEqual.cs
+++ b/WebAssembly/Instructions/Float32NotEqual.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32NotEqual : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32NotEqual"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32NotEqual"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32NotEqual;
 

--- a/WebAssembly/Instructions/Float32ReinterpretInt32.cs
+++ b/WebAssembly/Instructions/Float32ReinterpretInt32.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float32ReinterpretInt32 : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32ReinterpretInt32"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32ReinterpretInt32"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32ReinterpretInt32;
 

--- a/WebAssembly/Instructions/Float32SquareRoot.cs
+++ b/WebAssembly/Instructions/Float32SquareRoot.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Float32SquareRoot : Float64CallWrapperInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32SquareRoot"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32SquareRoot"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32SquareRoot;
 

--- a/WebAssembly/Instructions/Float32Store.cs
+++ b/WebAssembly/Instructions/Float32Store.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float32Store : MemoryWriteInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Store"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Store"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Store;
 

--- a/WebAssembly/Instructions/Float32Subtract.cs
+++ b/WebAssembly/Instructions/Float32Subtract.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float32Subtract : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Subtract"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Subtract"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Subtract;
 

--- a/WebAssembly/Instructions/Float32Truncate.cs
+++ b/WebAssembly/Instructions/Float32Truncate.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Float32Truncate : Float64CallWrapperInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float32Truncate"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float32Truncate"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float32Truncate;
 

--- a/WebAssembly/Instructions/Float64Absolute.cs
+++ b/WebAssembly/Instructions/Float64Absolute.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float64Absolute : ValueOneToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Absolute"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Absolute"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Absolute;
 

--- a/WebAssembly/Instructions/Float64Add.cs
+++ b/WebAssembly/Instructions/Float64Add.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64Add : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Add"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Add"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Add;
 

--- a/WebAssembly/Instructions/Float64Ceiling.cs
+++ b/WebAssembly/Instructions/Float64Ceiling.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float64Ceiling : ValueOneToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Ceiling"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Ceiling"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Ceiling;
 

--- a/WebAssembly/Instructions/Float64Constant.cs
+++ b/WebAssembly/Instructions/Float64Constant.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float64Constant : Constant<double>
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Constant"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Constant"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Constant;
 

--- a/WebAssembly/Instructions/Float64ConvertInt32Signed.cs
+++ b/WebAssembly/Instructions/Float64ConvertInt32Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float64ConvertInt32Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64ConvertInt32Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64ConvertInt32Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64ConvertInt32Signed;
 

--- a/WebAssembly/Instructions/Float64ConvertInt32Unsigned.cs
+++ b/WebAssembly/Instructions/Float64ConvertInt32Unsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float64ConvertInt32Unsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64ConvertInt32Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64ConvertInt32Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64ConvertInt32Unsigned;
 

--- a/WebAssembly/Instructions/Float64ConvertInt64Signed.cs
+++ b/WebAssembly/Instructions/Float64ConvertInt64Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float64ConvertInt64Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64ConvertInt64Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64ConvertInt64Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64ConvertInt64Signed;
 

--- a/WebAssembly/Instructions/Float64ConvertInt64Unsigned.cs
+++ b/WebAssembly/Instructions/Float64ConvertInt64Unsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float64ConvertInt64Unsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64ConvertInt64Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64ConvertInt64Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64ConvertInt64Unsigned;
 

--- a/WebAssembly/Instructions/Float64CopySign.cs
+++ b/WebAssembly/Instructions/Float64CopySign.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float64CopySign : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64CopySign"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64CopySign"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64CopySign;
 

--- a/WebAssembly/Instructions/Float64Divide.cs
+++ b/WebAssembly/Instructions/Float64Divide.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64Divide : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Divide"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Divide"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Divide;
 

--- a/WebAssembly/Instructions/Float64Equal.cs
+++ b/WebAssembly/Instructions/Float64Equal.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64Equal : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Equal"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Equal"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Equal;
 

--- a/WebAssembly/Instructions/Float64Floor.cs
+++ b/WebAssembly/Instructions/Float64Floor.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float64Floor : ValueOneToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Floor"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Floor"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Floor;
 

--- a/WebAssembly/Instructions/Float64GreaterThan.cs
+++ b/WebAssembly/Instructions/Float64GreaterThan.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64GreaterThan : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64GreaterThan"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64GreaterThan"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64GreaterThan;
 

--- a/WebAssembly/Instructions/Float64GreaterThanOrEqual.cs
+++ b/WebAssembly/Instructions/Float64GreaterThanOrEqual.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64GreaterThanOrEqual : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64GreaterThanOrEqual"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64GreaterThanOrEqual"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64GreaterThanOrEqual;
 

--- a/WebAssembly/Instructions/Float64LessThan.cs
+++ b/WebAssembly/Instructions/Float64LessThan.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64LessThan : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64LessThan"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64LessThan"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64LessThan;
 

--- a/WebAssembly/Instructions/Float64LessThanOrEqual.cs
+++ b/WebAssembly/Instructions/Float64LessThanOrEqual.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64LessThanOrEqual : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64LessThanOrEqual"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64LessThanOrEqual"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64LessThanOrEqual;
 

--- a/WebAssembly/Instructions/Float64Load.cs
+++ b/WebAssembly/Instructions/Float64Load.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Float64Load : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Load"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Load"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Load;
 

--- a/WebAssembly/Instructions/Float64Maximum.cs
+++ b/WebAssembly/Instructions/Float64Maximum.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float64Maximum : ValueTwoToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Maximum"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Maximum"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Maximum;
 

--- a/WebAssembly/Instructions/Float64Minimum.cs
+++ b/WebAssembly/Instructions/Float64Minimum.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float64Minimum : ValueTwoToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Minimum"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Minimum"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Minimum;
 

--- a/WebAssembly/Instructions/Float64Multiply.cs
+++ b/WebAssembly/Instructions/Float64Multiply.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64Multiply : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Multiply"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Multiply"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Multiply;
 

--- a/WebAssembly/Instructions/Float64Nearest.cs
+++ b/WebAssembly/Instructions/Float64Nearest.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float64Nearest : ValueOneToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Nearest"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Nearest"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Nearest;
 

--- a/WebAssembly/Instructions/Float64Negate.cs
+++ b/WebAssembly/Instructions/Float64Negate.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Float64Negate : ValueOneToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Negate"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Negate"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Negate;
 

--- a/WebAssembly/Instructions/Float64NotEqual.cs
+++ b/WebAssembly/Instructions/Float64NotEqual.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64NotEqual : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64NotEqual"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64NotEqual"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64NotEqual;
 

--- a/WebAssembly/Instructions/Float64PromoteFloat32.cs
+++ b/WebAssembly/Instructions/Float64PromoteFloat32.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float64PromoteFloat32 : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64PromoteFloat32"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64PromoteFloat32"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64PromoteFloat32;
 

--- a/WebAssembly/Instructions/Float64ReinterpretInt64.cs
+++ b/WebAssembly/Instructions/Float64ReinterpretInt64.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float64ReinterpretInt64 : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64ReinterpretInt64"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64ReinterpretInt64"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64ReinterpretInt64;
 

--- a/WebAssembly/Instructions/Float64SquareRoot.cs
+++ b/WebAssembly/Instructions/Float64SquareRoot.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float64SquareRoot : ValueOneToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64SquareRoot"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64SquareRoot"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64SquareRoot;
 

--- a/WebAssembly/Instructions/Float64Store.cs
+++ b/WebAssembly/Instructions/Float64Store.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Float64Store : MemoryWriteInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Store"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Store"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Store;
 

--- a/WebAssembly/Instructions/Float64Subtract.cs
+++ b/WebAssembly/Instructions/Float64Subtract.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Float64Subtract : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Subtract"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Subtract"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Subtract;
 

--- a/WebAssembly/Instructions/Float64Truncate.cs
+++ b/WebAssembly/Instructions/Float64Truncate.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Float64Truncate : ValueOneToOneCallInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Float64Truncate"/>.
+    /// Always <see cref="WebAssembly.OpCode.Float64Truncate"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Float64Truncate;
 

--- a/WebAssembly/Instructions/GlobalGet.cs
+++ b/WebAssembly/Instructions/GlobalGet.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class GlobalGet : VariableAccessInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.GlobalGet"/>.
+    /// Always <see cref="WebAssembly.OpCode.GlobalGet"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.GlobalGet;
 

--- a/WebAssembly/Instructions/GlobalSet.cs
+++ b/WebAssembly/Instructions/GlobalSet.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class GlobalSet : VariableAccessInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.GlobalSet"/>.
+    /// Always <see cref="WebAssembly.OpCode.GlobalSet"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.GlobalSet;
 

--- a/WebAssembly/Instructions/If.cs
+++ b/WebAssembly/Instructions/If.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class If : BlockTypeInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.If"/>.
+    /// Always <see cref="WebAssembly.OpCode.If"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.If;
 

--- a/WebAssembly/Instructions/Int32Add.cs
+++ b/WebAssembly/Instructions/Int32Add.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32Add : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Add"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Add"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Add;
 

--- a/WebAssembly/Instructions/Int32And.cs
+++ b/WebAssembly/Instructions/Int32And.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32And : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32And"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32And"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32And;
 

--- a/WebAssembly/Instructions/Int32Constant.cs
+++ b/WebAssembly/Instructions/Int32Constant.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32Constant : Constant<int>
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Constant"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Constant"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Constant;
 

--- a/WebAssembly/Instructions/Int32CountLeadingZeroes.cs
+++ b/WebAssembly/Instructions/Int32CountLeadingZeroes.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int32CountLeadingZeroes : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32CountLeadingZeroes"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32CountLeadingZeroes"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32CountLeadingZeroes;
 

--- a/WebAssembly/Instructions/Int32CountOneBits.cs
+++ b/WebAssembly/Instructions/Int32CountOneBits.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int32CountOneBits : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32CountOneBits"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32CountOneBits"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32CountOneBits;
 

--- a/WebAssembly/Instructions/Int32CountTrailingZeroes.cs
+++ b/WebAssembly/Instructions/Int32CountTrailingZeroes.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int32CountTrailingZeroes : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32CountTrailingZeroes"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32CountTrailingZeroes"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32CountTrailingZeroes;
 

--- a/WebAssembly/Instructions/Int32DivideSigned.cs
+++ b/WebAssembly/Instructions/Int32DivideSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32DivideSigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32DivideSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32DivideSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32DivideSigned;
 

--- a/WebAssembly/Instructions/Int32DivideUnsigned.cs
+++ b/WebAssembly/Instructions/Int32DivideUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32DivideUnsigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32DivideUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32DivideUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32DivideUnsigned;
 

--- a/WebAssembly/Instructions/Int32Equal.cs
+++ b/WebAssembly/Instructions/Int32Equal.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32Equal : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Equal"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Equal"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Equal;
 

--- a/WebAssembly/Instructions/Int32EqualZero.cs
+++ b/WebAssembly/Instructions/Int32EqualZero.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32EqualZero : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32EqualZero"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32EqualZero"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32EqualZero;
 

--- a/WebAssembly/Instructions/Int32ExclusiveOr.cs
+++ b/WebAssembly/Instructions/Int32ExclusiveOr.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32ExclusiveOr : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32ExclusiveOr"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32ExclusiveOr"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32ExclusiveOr;
 

--- a/WebAssembly/Instructions/Int32Extend16Signed.cs
+++ b/WebAssembly/Instructions/Int32Extend16Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32Extend16Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Extend16Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Extend16Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Extend16Signed;
 

--- a/WebAssembly/Instructions/Int32Extend8Signed.cs
+++ b/WebAssembly/Instructions/Int32Extend8Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32Extend8Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Extend8Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Extend8Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Extend8Signed;
 

--- a/WebAssembly/Instructions/Int32GreaterThanOrEqualSigned.cs
+++ b/WebAssembly/Instructions/Int32GreaterThanOrEqualSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32GreaterThanOrEqualSigned : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32GreaterThanOrEqualSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32GreaterThanOrEqualSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32GreaterThanOrEqualSigned;
 

--- a/WebAssembly/Instructions/Int32GreaterThanOrEqualUnsigned.cs
+++ b/WebAssembly/Instructions/Int32GreaterThanOrEqualUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32GreaterThanOrEqualUnsigned : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32GreaterThanOrEqualUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32GreaterThanOrEqualUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32GreaterThanOrEqualUnsigned;
 

--- a/WebAssembly/Instructions/Int32GreaterThanSigned.cs
+++ b/WebAssembly/Instructions/Int32GreaterThanSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32GreaterThanSigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32GreaterThanSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32GreaterThanSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32GreaterThanSigned;
 

--- a/WebAssembly/Instructions/Int32GreaterThanUnsigned.cs
+++ b/WebAssembly/Instructions/Int32GreaterThanUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32GreaterThanUnsigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32GreaterThanUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32GreaterThanUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32GreaterThanUnsigned;
 

--- a/WebAssembly/Instructions/Int32LessThanOrEqualSigned.cs
+++ b/WebAssembly/Instructions/Int32LessThanOrEqualSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32LessThanOrEqualSigned : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32LessThanOrEqualSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32LessThanOrEqualSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32LessThanOrEqualSigned;
 

--- a/WebAssembly/Instructions/Int32LessThanOrEqualUnsigned.cs
+++ b/WebAssembly/Instructions/Int32LessThanOrEqualUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32LessThanOrEqualUnsigned : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32LessThanOrEqualUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32LessThanOrEqualUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32LessThanOrEqualUnsigned;
 

--- a/WebAssembly/Instructions/Int32LessThanSigned.cs
+++ b/WebAssembly/Instructions/Int32LessThanSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32LessThanSigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32LessThanSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32LessThanSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32LessThanSigned;
 

--- a/WebAssembly/Instructions/Int32LessThanUnsigned.cs
+++ b/WebAssembly/Instructions/Int32LessThanUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32LessThanUnsigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32LessThanUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32LessThanUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32LessThanUnsigned;
 

--- a/WebAssembly/Instructions/Int32Load.cs
+++ b/WebAssembly/Instructions/Int32Load.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int32Load : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Load"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Load"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Load;
 

--- a/WebAssembly/Instructions/Int32Load16Signed.cs
+++ b/WebAssembly/Instructions/Int32Load16Signed.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int32Load16Signed : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Load16Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Load16Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Load16Signed;
 

--- a/WebAssembly/Instructions/Int32Load16Unsigned.cs
+++ b/WebAssembly/Instructions/Int32Load16Unsigned.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int32Load16Unsigned : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Load16Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Load16Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Load16Unsigned;
 

--- a/WebAssembly/Instructions/Int32Load8Signed.cs
+++ b/WebAssembly/Instructions/Int32Load8Signed.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int32Load8Signed : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Load8Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Load8Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Load8Signed;
 

--- a/WebAssembly/Instructions/Int32Load8Unsigned.cs
+++ b/WebAssembly/Instructions/Int32Load8Unsigned.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int32Load8Unsigned : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Load8Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Load8Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Load8Unsigned;
 

--- a/WebAssembly/Instructions/Int32Multiply.cs
+++ b/WebAssembly/Instructions/Int32Multiply.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32Multiply : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Multiply"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Multiply"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Multiply;
 

--- a/WebAssembly/Instructions/Int32NotEqual.cs
+++ b/WebAssembly/Instructions/Int32NotEqual.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32NotEqual : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32NotEqual"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32NotEqual"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32NotEqual;
 

--- a/WebAssembly/Instructions/Int32Or.cs
+++ b/WebAssembly/Instructions/Int32Or.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32Or : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Or"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Or"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Or;
 

--- a/WebAssembly/Instructions/Int32ReinterpretFloat32.cs
+++ b/WebAssembly/Instructions/Int32ReinterpretFloat32.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32ReinterpretFloat32 : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32ReinterpretFloat32"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32ReinterpretFloat32"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32ReinterpretFloat32;
 

--- a/WebAssembly/Instructions/Int32RemainderSigned.cs
+++ b/WebAssembly/Instructions/Int32RemainderSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32RemainderSigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32RemainderSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32RemainderSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32RemainderSigned;
 

--- a/WebAssembly/Instructions/Int32RemainderUnsigned.cs
+++ b/WebAssembly/Instructions/Int32RemainderUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32RemainderUnsigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32RemainderUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32RemainderUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32RemainderUnsigned;
 

--- a/WebAssembly/Instructions/Int32RotateLeft.cs
+++ b/WebAssembly/Instructions/Int32RotateLeft.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int32RotateLeft : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32RotateLeft"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32RotateLeft"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32RotateLeft;
 

--- a/WebAssembly/Instructions/Int32RotateRight.cs
+++ b/WebAssembly/Instructions/Int32RotateRight.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int32RotateRight : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32RotateRight"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32RotateRight"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32RotateRight;
 

--- a/WebAssembly/Instructions/Int32ShiftLeft.cs
+++ b/WebAssembly/Instructions/Int32ShiftLeft.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32ShiftLeft : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32ShiftLeft"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32ShiftLeft"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32ShiftLeft;
 

--- a/WebAssembly/Instructions/Int32ShiftRightSigned.cs
+++ b/WebAssembly/Instructions/Int32ShiftRightSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32ShiftRightSigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32ShiftRightSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32ShiftRightSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32ShiftRightSigned;
 

--- a/WebAssembly/Instructions/Int32ShiftRightUnsigned.cs
+++ b/WebAssembly/Instructions/Int32ShiftRightUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32ShiftRightUnsigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32ShiftRightUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32ShiftRightUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32ShiftRightUnsigned;
 

--- a/WebAssembly/Instructions/Int32Store.cs
+++ b/WebAssembly/Instructions/Int32Store.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32Store : MemoryWriteInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Store"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Store"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Store;
 

--- a/WebAssembly/Instructions/Int32Store16.cs
+++ b/WebAssembly/Instructions/Int32Store16.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32Store16 : MemoryWriteInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Store16"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Store16"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Store16;
 

--- a/WebAssembly/Instructions/Int32Store8.cs
+++ b/WebAssembly/Instructions/Int32Store8.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32Store8 : MemoryWriteInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Store8"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Store8"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Store8;
 

--- a/WebAssembly/Instructions/Int32Subtract.cs
+++ b/WebAssembly/Instructions/Int32Subtract.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int32Subtract : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32Subtract"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32Subtract"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32Subtract;
 

--- a/WebAssembly/Instructions/Int32TruncateFloat32Signed.cs
+++ b/WebAssembly/Instructions/Int32TruncateFloat32Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32TruncateFloat32Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32TruncateFloat32Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32TruncateFloat32Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32TruncateFloat32Signed;
 

--- a/WebAssembly/Instructions/Int32TruncateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateFloat32Unsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32TruncateFloat32Unsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32TruncateFloat32Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32TruncateFloat32Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32TruncateFloat32Unsigned;
 

--- a/WebAssembly/Instructions/Int32TruncateFloat64Signed.cs
+++ b/WebAssembly/Instructions/Int32TruncateFloat64Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32TruncateFloat64Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32TruncateFloat64Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32TruncateFloat64Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32TruncateFloat64Signed;
 

--- a/WebAssembly/Instructions/Int32TruncateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateFloat64Unsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32TruncateFloat64Unsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32TruncateFloat64Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32TruncateFloat64Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32TruncateFloat64Unsigned;
 

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat32Signed.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat32Signed.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Int32TruncateSaturateFloat32Signed : TruncateSaturateInstruction
 {
     /// <summary>
-    /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed"/>.
+    /// Always <see cref="WebAssembly.MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed"/>.
     /// </summary>
     public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
         MiscellaneousOpCode.Int32TruncateSaturateFloat32Signed;

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat32Unsigned.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Int32TruncateSaturateFloat32Unsigned : TruncateSaturateInstruction
 {
     /// <summary>
-    /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned"/>.
+    /// Always <see cref="WebAssembly.MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned"/>.
     /// </summary>
     public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
         MiscellaneousOpCode.Int32TruncateSaturateFloat32Unsigned;

--- a/WebAssembly/Instructions/Int32TruncateSaturateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int32TruncateSaturateFloat64Unsigned.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Int32TruncateSaturateFloat64Unsigned : TruncateSaturateInstruction
 {
     /// <summary>
-    /// Always <see cref="MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned"/>.
+    /// Always <see cref="WebAssembly.MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned"/>.
     /// </summary>
     public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
         MiscellaneousOpCode.Int32TruncateSaturateFloat64Unsigned;

--- a/WebAssembly/Instructions/Int32WrapInt64.cs
+++ b/WebAssembly/Instructions/Int32WrapInt64.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int32WrapInt64 : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int32WrapInt64"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int32WrapInt64"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int32WrapInt64;
 

--- a/WebAssembly/Instructions/Int64Add.cs
+++ b/WebAssembly/Instructions/Int64Add.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64Add : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Add"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Add"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Add;
 

--- a/WebAssembly/Instructions/Int64And.cs
+++ b/WebAssembly/Instructions/Int64And.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64And : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64And"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64And"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64And;
 

--- a/WebAssembly/Instructions/Int64Constant.cs
+++ b/WebAssembly/Instructions/Int64Constant.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64Constant : Constant<long>
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Constant"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Constant"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Constant;
 

--- a/WebAssembly/Instructions/Int64CountLeadingZeroes.cs
+++ b/WebAssembly/Instructions/Int64CountLeadingZeroes.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int64CountLeadingZeroes : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64CountLeadingZeroes"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64CountLeadingZeroes"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64CountLeadingZeroes;
 

--- a/WebAssembly/Instructions/Int64CountOneBits.cs
+++ b/WebAssembly/Instructions/Int64CountOneBits.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int64CountOneBits : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64CountOneBits"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64CountOneBits"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64CountOneBits;
 

--- a/WebAssembly/Instructions/Int64CountTrailingZeroes.cs
+++ b/WebAssembly/Instructions/Int64CountTrailingZeroes.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int64CountTrailingZeroes : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64CountTrailingZeroes"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64CountTrailingZeroes"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64CountTrailingZeroes;
 

--- a/WebAssembly/Instructions/Int64DivideSigned.cs
+++ b/WebAssembly/Instructions/Int64DivideSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64DivideSigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64DivideSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64DivideSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64DivideSigned;
 

--- a/WebAssembly/Instructions/Int64DivideUnsigned.cs
+++ b/WebAssembly/Instructions/Int64DivideUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64DivideUnsigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64DivideUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64DivideUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64DivideUnsigned;
 

--- a/WebAssembly/Instructions/Int64Equal.cs
+++ b/WebAssembly/Instructions/Int64Equal.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64Equal : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Equal"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Equal"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Equal;
 

--- a/WebAssembly/Instructions/Int64EqualZero.cs
+++ b/WebAssembly/Instructions/Int64EqualZero.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64EqualZero : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64EqualZero"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64EqualZero"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64EqualZero;
 

--- a/WebAssembly/Instructions/Int64ExclusiveOr.cs
+++ b/WebAssembly/Instructions/Int64ExclusiveOr.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64ExclusiveOr : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64ExclusiveOr"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64ExclusiveOr"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64ExclusiveOr;
 

--- a/WebAssembly/Instructions/Int64Extend16Signed.cs
+++ b/WebAssembly/Instructions/Int64Extend16Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64Extend16Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Extend16Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Extend16Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Extend16Signed;
 

--- a/WebAssembly/Instructions/Int64Extend32Signed.cs
+++ b/WebAssembly/Instructions/Int64Extend32Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64Extend32Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Extend32Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Extend32Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Extend32Signed;
 

--- a/WebAssembly/Instructions/Int64Extend8Signed.cs
+++ b/WebAssembly/Instructions/Int64Extend8Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64Extend8Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Extend8Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Extend8Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Extend8Signed;
 

--- a/WebAssembly/Instructions/Int64ExtendInt32Signed.cs
+++ b/WebAssembly/Instructions/Int64ExtendInt32Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64ExtendInt32Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64ExtendInt32Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64ExtendInt32Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64ExtendInt32Signed;
 

--- a/WebAssembly/Instructions/Int64ExtendInt32Unsigned.cs
+++ b/WebAssembly/Instructions/Int64ExtendInt32Unsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64ExtendInt32Unsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64ExtendInt32Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64ExtendInt32Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64ExtendInt32Unsigned;
 

--- a/WebAssembly/Instructions/Int64GreaterThanOrEqualSigned.cs
+++ b/WebAssembly/Instructions/Int64GreaterThanOrEqualSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64GreaterThanOrEqualSigned : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64GreaterThanOrEqualSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64GreaterThanOrEqualSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64GreaterThanOrEqualSigned;
 

--- a/WebAssembly/Instructions/Int64GreaterThanOrEqualUnsigned.cs
+++ b/WebAssembly/Instructions/Int64GreaterThanOrEqualUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64GreaterThanOrEqualUnsigned : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64GreaterThanOrEqualUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64GreaterThanOrEqualUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64GreaterThanOrEqualUnsigned;
 

--- a/WebAssembly/Instructions/Int64GreaterThanSigned.cs
+++ b/WebAssembly/Instructions/Int64GreaterThanSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64GreaterThanSigned : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64GreaterThanSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64GreaterThanSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64GreaterThanSigned;
 

--- a/WebAssembly/Instructions/Int64GreaterThanUnsigned.cs
+++ b/WebAssembly/Instructions/Int64GreaterThanUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64GreaterThanUnsigned : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64GreaterThanUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64GreaterThanUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64GreaterThanUnsigned;
 

--- a/WebAssembly/Instructions/Int64LessThanOrEqualSigned.cs
+++ b/WebAssembly/Instructions/Int64LessThanOrEqualSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64LessThanOrEqualSigned : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64LessThanOrEqualSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64LessThanOrEqualSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64LessThanOrEqualSigned;
 

--- a/WebAssembly/Instructions/Int64LessThanOrEqualUnsigned.cs
+++ b/WebAssembly/Instructions/Int64LessThanOrEqualUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64LessThanOrEqualUnsigned : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64LessThanOrEqualUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64LessThanOrEqualUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64LessThanOrEqualUnsigned;
 

--- a/WebAssembly/Instructions/Int64LessThanSigned.cs
+++ b/WebAssembly/Instructions/Int64LessThanSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64LessThanSigned : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64LessThanSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64LessThanSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64LessThanSigned;
 

--- a/WebAssembly/Instructions/Int64LessThanUnsigned.cs
+++ b/WebAssembly/Instructions/Int64LessThanUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64LessThanUnsigned : ValueTwoToInt32Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64LessThanUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64LessThanUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64LessThanUnsigned;
 

--- a/WebAssembly/Instructions/Int64Load.cs
+++ b/WebAssembly/Instructions/Int64Load.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int64Load : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Load"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Load"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Load;
 

--- a/WebAssembly/Instructions/Int64Load16Signed.cs
+++ b/WebAssembly/Instructions/Int64Load16Signed.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int64Load16Signed : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Load16Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Load16Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Load16Signed;
 

--- a/WebAssembly/Instructions/Int64Load16Unsigned.cs
+++ b/WebAssembly/Instructions/Int64Load16Unsigned.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int64Load16Unsigned : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Load16Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Load16Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Load16Unsigned;
 

--- a/WebAssembly/Instructions/Int64Load32Signed.cs
+++ b/WebAssembly/Instructions/Int64Load32Signed.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int64Load32Signed : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Load32Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Load32Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Load32Signed;
 

--- a/WebAssembly/Instructions/Int64Load32Unsigned.cs
+++ b/WebAssembly/Instructions/Int64Load32Unsigned.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int64Load32Unsigned : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Load32Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Load32Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Load32Unsigned;
 

--- a/WebAssembly/Instructions/Int64Load8Signed.cs
+++ b/WebAssembly/Instructions/Int64Load8Signed.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int64Load8Signed : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Load8Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Load8Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Load8Signed;
 

--- a/WebAssembly/Instructions/Int64Load8Unsigned.cs
+++ b/WebAssembly/Instructions/Int64Load8Unsigned.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Int64Load8Unsigned : MemoryReadInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Load8Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Load8Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Load8Unsigned;
 

--- a/WebAssembly/Instructions/Int64Multiply.cs
+++ b/WebAssembly/Instructions/Int64Multiply.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64Multiply : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Multiply"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Multiply"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Multiply;
 

--- a/WebAssembly/Instructions/Int64NotEqual.cs
+++ b/WebAssembly/Instructions/Int64NotEqual.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64NotEqual : ValueTwoToInt32NotEqualZeroInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64NotEqual"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64NotEqual"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64NotEqual;
 

--- a/WebAssembly/Instructions/Int64Or.cs
+++ b/WebAssembly/Instructions/Int64Or.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64Or : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Or"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Or"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Or;
 

--- a/WebAssembly/Instructions/Int64ReinterpretFloat64.cs
+++ b/WebAssembly/Instructions/Int64ReinterpretFloat64.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64ReinterpretFloat64 : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64ReinterpretFloat64"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64ReinterpretFloat64"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64ReinterpretFloat64;
 

--- a/WebAssembly/Instructions/Int64RemainderSigned.cs
+++ b/WebAssembly/Instructions/Int64RemainderSigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64RemainderSigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64RemainderSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64RemainderSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64RemainderSigned;
 

--- a/WebAssembly/Instructions/Int64RemainderUnsigned.cs
+++ b/WebAssembly/Instructions/Int64RemainderUnsigned.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64RemainderUnsigned : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64RemainderUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64RemainderUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64RemainderUnsigned;
 

--- a/WebAssembly/Instructions/Int64RotateLeft.cs
+++ b/WebAssembly/Instructions/Int64RotateLeft.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int64RotateLeft : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64RotateLeft"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64RotateLeft"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64RotateLeft;
 

--- a/WebAssembly/Instructions/Int64RotateRight.cs
+++ b/WebAssembly/Instructions/Int64RotateRight.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Int64RotateRight : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64RotateRight"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64RotateRight"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64RotateRight;
 

--- a/WebAssembly/Instructions/Int64ShiftLeft.cs
+++ b/WebAssembly/Instructions/Int64ShiftLeft.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64ShiftLeft : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64ShiftLeft"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64ShiftLeft"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64ShiftLeft;
 

--- a/WebAssembly/Instructions/Int64ShiftRightSigned.cs
+++ b/WebAssembly/Instructions/Int64ShiftRightSigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64ShiftRightSigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64ShiftRightSigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64ShiftRightSigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64ShiftRightSigned;
 

--- a/WebAssembly/Instructions/Int64ShiftRightUnsigned.cs
+++ b/WebAssembly/Instructions/Int64ShiftRightUnsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64ShiftRightUnsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64ShiftRightUnsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64ShiftRightUnsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64ShiftRightUnsigned;
 

--- a/WebAssembly/Instructions/Int64Store.cs
+++ b/WebAssembly/Instructions/Int64Store.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64Store : MemoryWriteInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Store"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Store"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Store;
 

--- a/WebAssembly/Instructions/Int64Store16.cs
+++ b/WebAssembly/Instructions/Int64Store16.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64Store16 : MemoryWriteInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Store16"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Store16"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Store16;
 

--- a/WebAssembly/Instructions/Int64Store32.cs
+++ b/WebAssembly/Instructions/Int64Store32.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64Store32 : MemoryWriteInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Store32"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Store32"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Store32;
 

--- a/WebAssembly/Instructions/Int64Store8.cs
+++ b/WebAssembly/Instructions/Int64Store8.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64Store8 : MemoryWriteInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Store8"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Store8"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Store8;
 

--- a/WebAssembly/Instructions/Int64Subtract.cs
+++ b/WebAssembly/Instructions/Int64Subtract.cs
@@ -6,7 +6,7 @@ namespace WebAssembly.Instructions;
 public class Int64Subtract : ValueTwoToOneInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64Subtract"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64Subtract"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64Subtract;
 

--- a/WebAssembly/Instructions/Int64TruncateFloat32Signed.cs
+++ b/WebAssembly/Instructions/Int64TruncateFloat32Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64TruncateFloat32Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64TruncateFloat32Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64TruncateFloat32Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64TruncateFloat32Signed;
 

--- a/WebAssembly/Instructions/Int64TruncateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateFloat32Unsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64TruncateFloat32Unsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64TruncateFloat32Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64TruncateFloat32Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64TruncateFloat32Unsigned;
 

--- a/WebAssembly/Instructions/Int64TruncateFloat64Signed.cs
+++ b/WebAssembly/Instructions/Int64TruncateFloat64Signed.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64TruncateFloat64Signed : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64TruncateFloat64Signed"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64TruncateFloat64Signed"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64TruncateFloat64Signed;
 

--- a/WebAssembly/Instructions/Int64TruncateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateFloat64Unsigned.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class Int64TruncateFloat64Unsigned : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Int64TruncateFloat64Unsigned"/>.
+    /// Always <see cref="WebAssembly.OpCode.Int64TruncateFloat64Unsigned"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Int64TruncateFloat64Unsigned;
 

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat32Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat32Unsigned.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Int64TruncateSaturateFloat32Unsigned : TruncateSaturateInstruction
 {
     /// <summary>
-    /// Always <see cref="MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned"/>.
+    /// Always <see cref="WebAssembly.MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned"/>.
     /// </summary>
     public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
         MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned;

--- a/WebAssembly/Instructions/Int64TruncateSaturateFloat64Unsigned.cs
+++ b/WebAssembly/Instructions/Int64TruncateSaturateFloat64Unsigned.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Int64TruncateSaturateFloat64Unsigned : TruncateSaturateInstruction
 {
     /// <summary>
-    /// Always <see cref="MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned"/>.
+    /// Always <see cref="WebAssembly.MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned"/>.
     /// </summary>
     public sealed override MiscellaneousOpCode MiscellaneousOpCode =>
         MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned;

--- a/WebAssembly/Instructions/LocalGet.cs
+++ b/WebAssembly/Instructions/LocalGet.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class LocalGet : VariableAccessInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.LocalGet"/>.
+    /// Always <see cref="WebAssembly.OpCode.LocalGet"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.LocalGet;
 

--- a/WebAssembly/Instructions/LocalSet.cs
+++ b/WebAssembly/Instructions/LocalSet.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class LocalSet : VariableAccessInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.LocalSet"/>.
+    /// Always <see cref="WebAssembly.OpCode.LocalSet"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.LocalSet;
 

--- a/WebAssembly/Instructions/LocalTee.cs
+++ b/WebAssembly/Instructions/LocalTee.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class LocalTee : VariableAccessInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.LocalTee"/>.
+    /// Always <see cref="WebAssembly.OpCode.LocalTee"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.LocalTee;
 

--- a/WebAssembly/Instructions/Loop.cs
+++ b/WebAssembly/Instructions/Loop.cs
@@ -8,7 +8,7 @@ namespace WebAssembly.Instructions;
 public class Loop : BlockTypeInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Loop"/>.
+    /// Always <see cref="WebAssembly.OpCode.Loop"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Loop;
 

--- a/WebAssembly/Instructions/MemoryGrow.cs
+++ b/WebAssembly/Instructions/MemoryGrow.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class MemoryGrow : Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.MemoryGrow"/>.
+    /// Always <see cref="WebAssembly.OpCode.MemoryGrow"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.MemoryGrow;
 

--- a/WebAssembly/Instructions/MemorySize.cs
+++ b/WebAssembly/Instructions/MemorySize.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class MemorySize : Instruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.MemorySize"/>.
+    /// Always <see cref="WebAssembly.OpCode.MemorySize"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.MemorySize;
 

--- a/WebAssembly/Instructions/MiscellaneousInstruction.cs
+++ b/WebAssembly/Instructions/MiscellaneousInstruction.cs
@@ -10,7 +10,7 @@ public abstract class MiscellaneousInstruction : Instruction
     }
 
     /// <summary>
-    /// Always <see cref="OpCode.MiscellaneousOperationPrefix"/>.
+    /// Always <see cref="WebAssembly.OpCode.MiscellaneousOperationPrefix"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.MiscellaneousOperationPrefix;
 

--- a/WebAssembly/Instructions/NoOperation.cs
+++ b/WebAssembly/Instructions/NoOperation.cs
@@ -9,7 +9,7 @@ namespace WebAssembly.Instructions;
 public class NoOperation : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.NoOperation"/>.
+    /// Always <see cref="WebAssembly.OpCode.NoOperation"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.NoOperation;
 

--- a/WebAssembly/Instructions/Return.cs
+++ b/WebAssembly/Instructions/Return.cs
@@ -10,7 +10,7 @@ namespace WebAssembly.Instructions;
 public class Return : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Return"/>.
+    /// Always <see cref="WebAssembly.OpCode.Return"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Return;
 

--- a/WebAssembly/Instructions/Select.cs
+++ b/WebAssembly/Instructions/Select.cs
@@ -12,7 +12,7 @@ namespace WebAssembly.Instructions;
 public class Select : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Select"/>.
+    /// Always <see cref="WebAssembly.OpCode.Select"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Select;
 

--- a/WebAssembly/Instructions/Unreachable.cs
+++ b/WebAssembly/Instructions/Unreachable.cs
@@ -13,7 +13,7 @@ namespace WebAssembly.Instructions;
 public class Unreachable : SimpleInstruction
 {
     /// <summary>
-    /// Always <see cref="OpCode.Unreachable"/>.
+    /// Always <see cref="WebAssembly.OpCode.Unreachable"/>.
     /// </summary>
     public sealed override OpCode OpCode => OpCode.Unreachable;
 

--- a/WebAssembly/Memory.cs
+++ b/WebAssembly/Memory.cs
@@ -33,7 +33,7 @@ public class Memory
     }
 
     /// <summary>
-    /// Creates a new <see cref="Memory"/> instance with the provided <see cref="ResizableLimits.Minimum"/> and <see cref="ResizableLimits.Maximum"/> values.
+    /// Creates a new <see cref="Memory"/> instance with the provided <see cref="WebAssembly.ResizableLimits.Minimum"/> and <see cref="WebAssembly.ResizableLimits.Maximum"/> values.
     /// </summary>
     /// <param name="minimum">Initial length (in units of table elements or 65,536-byte pages).</param>
     /// <param name="maximum">Maximum length (in units of table elements or 65,536-byte pages).</param>

--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable CS0618 // Type or member is obsolete: used for internal methods
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/WebAssembly/Runtime/ImportDictionary.cs
+++ b/WebAssembly/Runtime/ImportDictionary.cs
@@ -7,7 +7,7 @@ namespace WebAssembly.Runtime;
 /// No members of its own, essentially an alias for a dictionary of dictionaries,
 /// both keyed by strings, with the inner dictionary having values of <see cref="RuntimeImport"/>.
 /// </summary>
-public class ImportDictionary : Dictionary<string, IDictionary<string, RuntimeImport>>, IDictionary<string, IDictionary<string, RuntimeImport>>
+public class ImportDictionary : Dictionary<string, IDictionary<string, RuntimeImport>>
 {
     /// <summary>
     /// Creates a new <see cref="ImportDictionary"/> instance.

--- a/WebAssembly/Runtime/OpCodeCompilationException.cs
+++ b/WebAssembly/Runtime/OpCodeCompilationException.cs
@@ -34,7 +34,7 @@ public class OpCodeCompilationException : CompilerException
     public OpCode OpCode { get; }
 
     /// <summary>
-    /// The miscellaneous operation attempted, if <see cref="OpCode"/> is <see cref="OpCode.MiscellaneousOperationPrefix"/>.
+    /// The miscellaneous operation attempted, if <see cref="OpCode"/> is <see cref="WebAssembly.OpCode.MiscellaneousOperationPrefix"/>.
     /// </summary>
     public MiscellaneousOpCode? MiscellaneousOpCode { get; }
 }

--- a/WebAssembly/Table.cs
+++ b/WebAssembly/Table.cs
@@ -34,7 +34,7 @@ public class Table
     }
 
     /// <summary>
-    /// Creates a new <see cref="Table"/> instance with the provided <see cref="ResizableLimits.Minimum"/> and <see cref="ResizableLimits.Maximum"/> values.
+    /// Creates a new <see cref="Table"/> instance with the provided <see cref="WebAssembly.ResizableLimits.Minimum"/> and <see cref="WebAssembly.ResizableLimits.Maximum"/> values.
     /// </summary>
     /// <param name="minimum">Initial length (in units of table elements or 65,536-byte pages).</param>
     /// <param name="maximum">Maximum length (in units of table elements or 65,536-byte pages).</param>


### PR DESCRIPTION
This PR fixes a couple of Rider errors:

1. **Unreachable code detected (empty `;` blocks)**
    ![image](https://user-images.githubusercontent.com/2109929/209131625-296327aa-f5c1-49d1-a511-fca4b0735e65.png)
2. **Property is used instead of type in `<see cref="">`**
    If there is a property that has the same name of the type, the property is being used in `<see cref="">`. Because the enum instance doesn't have the property name (e.g. Block), it'll show an error.
    ![image](https://user-images.githubusercontent.com/2109929/209131855-d7debb7a-bdf4-4179-9b89-80ed5c5a3a45.png)
 3. **Null-types doesn't match**
    Because the dictionary already implements the interface, I simply removed it.
    ![image](https://user-images.githubusercontent.com/2109929/209132190-0689d2a6-223d-4b58-a0e3-b9a87c2d7dac.png)
4. **Usage of obsolete method**
    In the helpers class an method is marked as obsolete because it only should be used internally. Because of this Rider complains the method shouldn't be used. I've added a `#pragma warning disable` in the file where this method is used. Maybe it's better to change the class to `internal` instead of `public` but this would cause an API change.
    ![image](https://user-images.githubusercontent.com/2109929/209132401-182dec66-4fe5-4d5e-83a9-125f3108a7e8.png)