### PR TITLE
Add Bulk Memory Instructions

### DIFF
--- a/WebAssembly/Instruction.cs
+++ b/WebAssembly/Instruction.cs
@@ -313,9 +313,22 @@ public abstract class Instruction : IEquatable<Instruction>
                         case MiscellaneousOpCode.Int64TruncateSaturateFloat32Unsigned: yield return new Int64TruncateSaturateFloat32Unsigned(); break;
                         case MiscellaneousOpCode.Int64TruncateSaturateFloat64Signed: yield return new Int64TruncateSaturateFloat64Signed(); break;
                         case MiscellaneousOpCode.Int64TruncateSaturateFloat64Unsigned: yield return new Int64TruncateSaturateFloat64Unsigned(); break;
+                        case MiscellaneousOpCode.MemoryCopy: SkipBytes(reader, 2); yield return new MemoryCopy(); break;
+                        case MiscellaneousOpCode.MemoryFill: SkipBytes(reader, 1); yield return new MemoryFill(); break;
+                        case MiscellaneousOpCode.TableInit: yield return new TableInit(reader); break;
+                        case MiscellaneousOpCode.TableCopy: yield return new TableCopy(reader); break;
+                        case MiscellaneousOpCode.MemoryInit: yield return new MemoryInit(reader); break;
+                        case MiscellaneousOpCode.DataDrop: yield return new DataDrop(reader); break;
+                        case MiscellaneousOpCode.ElemDrop: yield return new ElemDrop(reader); break;
                     }
                     break;
             }
         }
+    }
+
+    private static void SkipBytes(Reader reader, int count)
+    {
+        for(; count > 0; count--)
+            reader.ReadByte();
     }
 }

--- a/WebAssembly/Instructions/DataDrop.cs
+++ b/WebAssembly/Instructions/DataDrop.cs
@@ -1,0 +1,35 @@
+﻿using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions;
+
+/// <summary>
+/// Prevent further use of passive data segment
+/// </summary>
+public sealed class DataDrop : MiscellaneousInstruction
+{
+    /// <summary>
+    /// Creates a new  <see cref="DataDrop"/> instance.
+    /// </summary>
+    public DataDrop(uint dataIdx) => DataIdx = dataIdx;
+
+    internal DataDrop(Reader reader) => DataIdx = reader.ReadVarUInt32(); // segment:varuint32
+
+    /// <inheritdoc/>
+    public override MiscellaneousOpCode MiscellaneousOpCode => MiscellaneousOpCode.DataDrop;
+
+    /// <summary>
+    /// Passive data segment Idx
+    /// </summary>
+    public uint DataIdx;
+
+    internal override void WriteTo(Writer writer)
+    {
+        base.WriteTo(writer);
+        writer.WriteVar(DataIdx);
+    }
+
+    internal override void Compile(CompilationContext context)
+    {
+        // TODO: add trap
+    }
+}

--- a/WebAssembly/Instructions/DataDrop.cs
+++ b/WebAssembly/Instructions/DataDrop.cs
@@ -10,6 +10,11 @@ public sealed class DataDrop : MiscellaneousInstruction
     /// <summary>
     /// Creates a new  <see cref="DataDrop"/> instance.
     /// </summary>
+    public DataDrop() { }
+
+    /// <summary>
+    /// Creates a new  <see cref="DataDrop"/> instance.
+    /// </summary>
     public DataDrop(uint dataIdx) => DataIdx = dataIdx;
 
     internal DataDrop(Reader reader) => DataIdx = reader.ReadVarUInt32(); // segment:varuint32

--- a/WebAssembly/Instructions/ElemDrop.cs
+++ b/WebAssembly/Instructions/ElemDrop.cs
@@ -1,0 +1,35 @@
+﻿using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions;
+
+/// <summary>
+/// Prevent further use of passive data segment
+/// </summary>
+public sealed class ElemDrop : MiscellaneousInstruction
+{
+    /// <summary>
+    /// Creates a new  <see cref="ElemDrop"/> instance.
+    /// </summary>
+    public ElemDrop(uint elemIdx) => ElemIdx = elemIdx;
+
+    internal ElemDrop(Reader reader) => ElemIdx = reader.ReadVarUInt32(); // segment:varuint32
+
+    /// <inheritdoc/>
+    public override MiscellaneousOpCode MiscellaneousOpCode => MiscellaneousOpCode.ElemDrop;
+
+    /// <summary>
+    /// Passive data segment Idx
+    /// </summary>
+    public uint ElemIdx;
+
+    internal override void WriteTo(Writer writer)
+    {
+        base.WriteTo(writer);
+        writer.WriteVar(ElemIdx);
+    }
+
+    internal override void Compile(CompilationContext context)
+    {
+        // TODO: add trap
+    }
+}

--- a/WebAssembly/Instructions/ElemDrop.cs
+++ b/WebAssembly/Instructions/ElemDrop.cs
@@ -10,6 +10,11 @@ public sealed class ElemDrop : MiscellaneousInstruction
     /// <summary>
     /// Creates a new  <see cref="ElemDrop"/> instance.
     /// </summary>
+    public ElemDrop() { }
+
+    /// <summary>
+    /// Creates a new  <see cref="ElemDrop"/> instance.
+    /// </summary>
     public ElemDrop(uint elemIdx) => ElemIdx = elemIdx;
 
     internal ElemDrop(Reader reader) => ElemIdx = reader.ReadVarUInt32(); // segment:varuint32

--- a/WebAssembly/Instructions/MemoryCopy.cs
+++ b/WebAssembly/Instructions/MemoryCopy.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Xml.Schema;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions;
+/// <summary>
+/// Copy from one region of linear memory to another region
+/// </summary>
+public sealed class MemoryCopy : MiscellaneousInstruction
+{
+    /// <summary>
+    /// Always <see cref="MiscellaneousOpCode.MemoryCopy"/>.
+    /// </summary>
+    public override MiscellaneousOpCode MiscellaneousOpCode => MiscellaneousOpCode.MemoryCopy;
+
+    internal override void WriteTo(Writer writer)
+    {
+        base.WriteTo(writer);
+        writer.Write(0);
+        writer.Write(0);
+    }
+
+    internal override void Compile(CompilationContext context)
+    {
+        context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int32); // length
+        context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int32); // dest_index
+        context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int32); // start_index
+
+        context.EmitLoadThis();
+        context.Emit(OpCodes.Ldfld, context.CheckedMemory);
+        context.Emit(OpCodes.Call, UnmanagedMemory.StartGetter);
+        
+        context.Emit(OpCodes.Call, context[HelperMethod.MemoryCopy, (_, c) =>
+        {
+            var builder = c.CheckedExportsBuilder.DefineMethod(
+                 "☣ MemoryFill",
+                 CompilationContext.HelperMethodAttributes,
+                 typeof(void),
+                 [
+                        typeof(uint),  // len 0
+                        typeof(byte*), // src 1
+                        typeof(byte*), // dst 2
+                        typeof(IntPtr) // mem 3
+                 ]);
+
+            var il = builder.GetILGenerator();
+
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_S, (byte)3);
+            il.Emit(OpCodes.Add); // src = start_index + mem
+
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Ldarg_S, (byte)3);
+            il.Emit(OpCodes.Add); // dest = dest_index + mem
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Call, MemCpy); // src dest len len
+            il.Emit(OpCodes.Ret);
+
+            return builder;
+        }
+        ]);
+    }
+
+    private readonly static MethodInfo MemCpy = typeof(Buffer).GetMethod(nameof(Buffer.MemoryCopy),
+        [typeof(void*), typeof(void*), typeof(long), typeof(long)])!;
+}

--- a/WebAssembly/Instructions/MemoryFill.cs
+++ b/WebAssembly/Instructions/MemoryFill.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using WebAssembly.Runtime;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions;
+/// <summary>
+/// Fill a region of linear memory with a given byte value
+/// </summary>
+public sealed class MemoryFill : MiscellaneousInstruction
+{
+    /// <summary>
+    /// Always <see cref="MiscellaneousOpCode.MemoryFill"/>.
+    /// </summary>
+    public override MiscellaneousOpCode MiscellaneousOpCode => MiscellaneousOpCode.MemoryFill;
+
+    internal override void WriteTo(Writer writer)
+    {
+        base.WriteTo(writer);
+        writer.Write(0);
+    }
+
+    internal override void Compile(CompilationContext context)
+    {
+        context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int32); // length
+        context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int32); // value
+        context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int32); // start_index
+
+        context.EmitLoadThis();
+        context.Emit(OpCodes.Ldfld, context.CheckedMemory);
+        context.Emit(OpCodes.Call, UnmanagedMemory.StartGetter);
+        context.Emit(OpCodes.Add); // src = (byte*)(mem + start_index)
+
+        context.Emit(OpCodes.Call, context[HelperMethod.MemoryFill, (_, c) =>
+        {
+            var builder = c.CheckedExportsBuilder.DefineMethod(
+                 "☣ MemoryFill",
+                 CompilationContext.HelperMethodAttributes,
+                 typeof(void),
+                 [
+                        typeof(uint), // len
+                        typeof(byte), // value
+                        typeof(byte*),// dest
+                 ]);
+
+            var il = builder.GetILGenerator();
+            var loop_body = il.DefineLabel();
+            var loop_head = il.DefineLabel();
+
+            il.Emit(OpCodes.Br_S, loop_head);
+
+            il.MarkLabel(loop_body);
+
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Stind_I1); // *dest = byte;
+
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Starg_S, (byte)2); // dest++
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Starg_S, (byte)0); // len--
+
+            il.MarkLabel(loop_head);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Bgt_Un_S, loop_body);
+
+            il.Emit(OpCodes.Ret);
+
+            return builder;
+        } ]);
+    }
+}

--- a/WebAssembly/Instructions/MemoryInit.cs
+++ b/WebAssembly/Instructions/MemoryInit.cs
@@ -1,0 +1,98 @@
+﻿using System.Reflection.Emit;
+using System.Reflection;
+using System;
+using WebAssembly.Runtime.Compilation;
+using WebAssembly.Runtime;
+
+namespace WebAssembly.Instructions;
+/// <summary>
+/// Copy from a passive data segment to linear memory
+/// </summary>
+public sealed class MemoryInit : MiscellaneousInstruction
+{
+    /// <summary>
+    /// Creates a new  <see cref="MemoryInit"/> instance.
+    /// </summary>
+    public MemoryInit(uint dataIdx) { DataIdx = dataIdx; }
+
+    internal MemoryInit(Reader reader)
+    {
+        // memory.init	0xfc 0x08	segment:varuint32, memory:0x00
+        DataIdx = reader.ReadVarUInt32(); // segment
+        reader.ReadByte(); // memory
+    }
+
+    /// <summary>
+    /// Passive data segment Idx
+    /// </summary>
+    public uint DataIdx;
+
+    /// <inheritdoc/>
+    public override MiscellaneousOpCode MiscellaneousOpCode => MiscellaneousOpCode.MemoryInit;
+
+    internal override void WriteTo(Writer writer)
+    {
+        base.WriteTo(writer);
+        writer.WriteVar(DataIdx);
+        writer.Write(0);
+    }
+
+    internal override void Compile(CompilationContext context)
+    {
+        context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int32); // length
+        context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int32); // source offset
+        context.PopStackNoReturn(this.OpCode, WebAssemblyValueType.Int32); // target offset
+
+        context.EmitLoadThis();
+        context.Emit(OpCodes.Ldfld, context.CheckedMemory);
+        context.Emit(OpCodes.Call, UnmanagedMemory.StartGetter);
+
+        context.Emit(OpCodes.Call, context.DataGetters[(int)DataIdx]); // TODO: check for drop and throw trap
+
+        context.Emit(OpCodes.Call, context[HelperMethod.MemoryInit, (_, c) =>
+        {
+            var builder = c.CheckedExportsBuilder.DefineMethod(
+                 "☣ MemoryInit",
+                 CompilationContext.HelperMethodAttributes,
+                 typeof(void),
+                 [
+                        typeof(uint),  // len      0
+                        typeof(uint),  // src_off  1
+                        typeof(uint),  // tar_off  2
+                        typeof(IntPtr),// mem      3
+                        typeof(byte*), // data     4
+                 ]);
+
+            var il = builder.GetILGenerator();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, write);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, write);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, write);
+
+
+            il.Emit(OpCodes.Ldarg_2); // push target offset
+            il.Emit(OpCodes.Ldarg_S, (byte)4); // push data
+            il.Emit(OpCodes.Add); // src = target offset + data
+
+            il.Emit(OpCodes.Ldarg_1); // push source offset
+            il.Emit(OpCodes.Ldarg_S, (byte)3); // push mem
+            il.Emit(OpCodes.Add); // dest = mem + source offset
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Call, MemCpy); // src dest len len
+            il.Emit(OpCodes.Ret);
+
+            return builder;
+        }
+        ]);
+    }
+
+    private readonly static MethodInfo write = typeof(Console).GetMethod(nameof(Console.WriteLine), [typeof(int)])!;
+
+    private readonly static MethodInfo MemCpy = typeof(Buffer).GetMethod(nameof(Buffer.MemoryCopy),
+        [typeof(void*), typeof(void*), typeof(long), typeof(long)])!;
+}

--- a/WebAssembly/Instructions/MemoryInit.cs
+++ b/WebAssembly/Instructions/MemoryInit.cs
@@ -13,7 +13,12 @@ public sealed class MemoryInit : MiscellaneousInstruction
     /// <summary>
     /// Creates a new  <see cref="MemoryInit"/> instance.
     /// </summary>
-    public MemoryInit(uint dataIdx) { DataIdx = dataIdx; }
+    public MemoryInit() { }
+
+    /// <summary>
+    /// Creates a new  <see cref="MemoryInit"/> instance.
+    /// </summary>
+    public MemoryInit(uint dataIdx) => DataIdx = dataIdx;
 
     internal MemoryInit(Reader reader)
     {

--- a/WebAssembly/Instructions/MiscellaneousInstruction.cs
+++ b/WebAssembly/Instructions/MiscellaneousInstruction.cs
@@ -19,7 +19,7 @@ public abstract class MiscellaneousInstruction : Instruction
     /// </summary>
     public abstract MiscellaneousOpCode MiscellaneousOpCode { get; }
 
-    internal sealed override void WriteTo(Writer writer)
+    internal override void WriteTo(Writer writer)
     {
         writer.Write((byte)this.OpCode);
         writer.Write((byte)this.MiscellaneousOpCode);

--- a/WebAssembly/Instructions/TableCopy.cs
+++ b/WebAssembly/Instructions/TableCopy.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions;
+
+/// <summary>
+/// Copy from one region of a table to another region
+/// </summary>
+public sealed class TableCopy : MiscellaneousInstruction
+{
+    /// <summary>
+    /// Creates a new  <see cref="TableCopy"/> instance.
+    /// </summary>
+    public TableCopy() { }
+
+    internal TableCopy(Reader reader)
+    {
+        reader.ReadByte(); // table_dst:0x00 table_src:0x00
+        reader.ReadByte();
+    }
+
+    /// <inheritdoc/>
+    public override MiscellaneousOpCode MiscellaneousOpCode => MiscellaneousOpCode.TableCopy;
+
+    internal override void WriteTo(Writer writer)
+    {
+        base.WriteTo(writer);
+        writer.Write(0);
+        writer.Write(0);    
+    }
+
+    internal override void Compile(CompilationContext context)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/WebAssembly/Instructions/TableInit.cs
+++ b/WebAssembly/Instructions/TableInit.cs
@@ -12,6 +12,11 @@ public sealed class TableInit : MiscellaneousInstruction
     /// <summary>
     /// Creates a new  <see cref="TableInit"/> instance.
     /// </summary>
+    public TableInit() { }
+
+    /// <summary>
+    /// Creates a new  <see cref="TableInit"/> instance.
+    /// </summary>
     public TableInit(uint segment) => Segment = segment;
 
     internal TableInit(Reader reader)

--- a/WebAssembly/Instructions/TableInit.cs
+++ b/WebAssembly/Instructions/TableInit.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Diagnostics.Contracts;
+using WebAssembly.Runtime.Compilation;
+
+namespace WebAssembly.Instructions;
+
+/// <summary>
+/// Copy from a passive element segment to a table
+/// </summary>
+public sealed class TableInit : MiscellaneousInstruction
+{
+    /// <summary>
+    /// Creates a new  <see cref="TableInit"/> instance.
+    /// </summary>
+    public TableInit(uint segment) => Segment = segment;
+
+    internal TableInit(Reader reader)
+    {
+        // segment:varuint32, table:0x00
+        Segment = reader.ReadVarUInt32(); 
+        reader.ReadByte();
+    }
+
+    /// <inheritdoc/>
+    public override MiscellaneousOpCode MiscellaneousOpCode => MiscellaneousOpCode.TableInit;
+
+    /// <summary>
+    /// Passive element segment
+    /// </summary>
+    public uint Segment;
+
+    internal override void WriteTo(Writer writer)
+    {
+        base.WriteTo(writer);
+        writer.WriteVar(Segment);
+        writer.Write(0);
+    }
+
+    internal override void Compile(CompilationContext context)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/WebAssembly/MiscellaneousOpCode.cs
+++ b/WebAssembly/MiscellaneousOpCode.cs
@@ -56,6 +56,66 @@ public enum MiscellaneousOpCode : byte
     /// </summary>
     [OpCodeCharacteristics("i64.trunc_sat_f64_u")]
     Int64TruncateSaturateFloat64Unsigned = 0x07,
+
+    /// <summary>
+    /// Copy from a passive data segment to linear memory
+    /// </summary>
+    [OpCodeCharacteristics("memory.init")]
+    MemoryInit = 0x08,
+
+    /// <summary>
+    /// Prevent further use of passive data segment
+    /// </summary>
+    [OpCodeCharacteristics("data.drop")]
+    DataDrop = 0x09,
+
+    /// <summary>
+    /// Copy from one region of linear memory to another region
+    /// </summary>
+    [OpCodeCharacteristics("memory.copy")]
+    MemoryCopy = 0x0A,
+
+    /// <summary>
+    /// Fill a region of linear memory with a given byte value
+    /// </summary>
+    [OpCodeCharacteristics("memory.fill")]
+    MemoryFill = 0x0B,
+
+    /// <summary>
+    /// Copy from a passive element segment to a table
+    /// </summary>
+    [OpCodeCharacteristics("table.init")]
+    TableInit = 0x0C,
+
+    /// <summary>
+    /// Prevent further use of a passive element segment
+    /// </summary>
+    [OpCodeCharacteristics("elem.drop")]
+    ElemDrop = 0x0D,
+
+    /// <summary>
+    /// Copy from one region of a table to another region
+    /// </summary>
+    [OpCodeCharacteristics("table.copy")]
+    TableCopy = 0x0E,
+
+    /// <summary>
+    /// Manipulate the size of a table
+    /// </summary>
+    [OpCodeCharacteristics("table.grow")]
+    TableGrow = 0x0F,
+
+    /// <summary>
+    /// Manipulate the size of a table
+    /// </summary>
+    [OpCodeCharacteristics("table.size")]
+    TableSize = 0x10,
+
+    /// <summary>
+    /// Fill a range in a table with a value
+    /// </summary>
+    [OpCodeCharacteristics("table.fill")]
+    TableFill = 0x11
 }
 
 static class MiscellaneousOpCodeExtensions

--- a/WebAssembly/Runtime/Compilation/CompilationContext.cs
+++ b/WebAssembly/Runtime/Compilation/CompilationContext.cs
@@ -81,6 +81,10 @@ internal sealed class CompilationContext
 
     public readonly Dictionary<uint, MethodBuilder> DelegateRemappersByType = new();
 
+    public readonly Dictionary<int, MethodBuilder> DataGetters = new();
+
+    public uint DataCount;
+
     public FieldBuilder? FunctionTable;
 
     internal const MethodAttributes HelperMethodAttributes =

--- a/WebAssembly/Runtime/Compilation/HelperMethod.cs
+++ b/WebAssembly/Runtime/Compilation/HelperMethod.cs
@@ -38,6 +38,9 @@ enum HelperMethod
     Int64RotateLeft,
     Int64RotateRight,
 #endif
+    MemoryFill,
+    MemoryCopy,
+    MemoryInit,
     Int32TruncateSaturateFloat32Signed,
     Int32TruncateSaturateFloat32Unsigned,
     Int32TruncateSaturateFloat64Signed,

--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -1284,6 +1284,7 @@ public static class Compile
 
             if (mode != 1) // skip for passive data
             {
+                var index = reader.ReadVarUInt32();
                 block.Compile(context); //Prevents "end" instruction of the initializer expression from becoming a return.
                 foreach (var instruction in Instruction.ParseInitializerExpression(reader))
                 {
@@ -1304,10 +1305,12 @@ public static class Compile
 
             var field = exportsBuilder.DefineInitializedData($"☣ Data {i}", data, FieldAttributes.Assembly | FieldAttributes.InitOnly);
 
-            var getter = context.DataGetters[i];
-            var getterIL = getter.GetILGenerator();
-            getterIL.Emit(OpCodes.Ldsflda, field);
-            getterIL.Emit(OpCodes.Ret);
+            if (context.DataGetters.TryGetValue(i, out var getter))
+            {
+                var getterIL = getter.GetILGenerator();
+                getterIL.Emit(OpCodes.Ldsflda, field);
+                getterIL.Emit(OpCodes.Ret);
+            }
 
             if (mode == 1)
                 continue; // no copy to mem for passive data

--- a/WebAssembly/Section.cs
+++ b/WebAssembly/Section.cs
@@ -52,7 +52,11 @@ public enum Section : byte
     /// <summary>
     /// Data segments.
     /// </summary>
-    Data
+    Data,
+    /// <summary>
+    /// Data count section
+    /// </summary>
+    DataCount
 }
 
 static class SectionExtensions

--- a/WebAssembly/Section.cs
+++ b/WebAssembly/Section.cs
@@ -61,5 +61,5 @@ public enum Section : byte
 
 static class SectionExtensions
 {
-    public static bool IsValid(this Section section) => section >= Section.None && section <= Section.Data;
+    public static bool IsValid(this Section section) => section >= Section.None && section <= Section.DataCount;
 }


### PR DESCRIPTION
Adds support for the missing instructions from this proposal:
https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md

I don't know how to implement table.*** since they are not in memory as they should be. Instead they are in the form of fields(