### PR TITLE
Fixing some code quality issues, highlighted by ReSharper

### DIFF
--- a/WebAssembly.Tests/MemoryWriteTestBase.cs
+++ b/WebAssembly.Tests/MemoryWriteTestBase.cs
@@ -60,6 +60,6 @@ where T : struct
             Code = instructions,
         });
 
-        return module.ToInstance<MemoryWriteTestBase<T>>(); ;
+        return module.ToInstance<MemoryWriteTestBase<T>>();
     }
 }

--- a/WebAssembly/FunctionBody.cs
+++ b/WebAssembly/FunctionBody.cs
@@ -125,7 +125,7 @@ public class FunctionBody : IEquatable<FunctionBody>
             }
 
             return !itemMoved && !othersMoved;
-        };
+        }
     }
 
     internal void WriteTo(Writer writer, byte[] buffer)

--- a/WebAssembly/Instructions/Branch.cs
+++ b/WebAssembly/Instructions/Branch.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Reflection.Emit;
 using WebAssembly.Runtime.Compilation;
 

--- a/WebAssembly/Instructions/BranchIf.cs
+++ b/WebAssembly/Instructions/BranchIf.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Reflection.Emit;
 using WebAssembly.Runtime.Compilation;
 

--- a/WebAssembly/Instructions/End.cs
+++ b/WebAssembly/Instructions/End.cs
@@ -36,7 +36,7 @@ public class End : SimpleInstruction
             if (returnsLength < stack.Count || (returnsLength > stack.Count && !context.IsUnreachable))
                 throw new StackSizeIncorrectException(OpCode.End, returnsLength, stack.Count);
 
-            Assert(returnsLength == 0 || returnsLength == 1); //WebAssembly doesn't currently offer multiple returns, which should be blocked earlier.
+            Assert(returnsLength is 0 or 1); //WebAssembly doesn't currently offer multiple returns, which should be blocked earlier.
 
             if (returnsLength == 1)
             {

--- a/WebAssembly/Instructions/Return.cs
+++ b/WebAssembly/Instructions/Return.cs
@@ -27,7 +27,7 @@ public class Return : SimpleInstruction
         var stack = context.Stack;
 
         var returnsLength = returns.Length;
-        Assert(returnsLength == 0 || returnsLength == 1); //WebAssembly doesn't currently offer multiple returns, which should be blocked earlier.
+        Assert(returnsLength is 0 or 1); //WebAssembly doesn't currently offer multiple returns, which should be blocked earlier.
 
         var stackCount = stack.Count;
 

--- a/WebAssembly/Module.cs
+++ b/WebAssembly/Module.cs
@@ -385,7 +385,7 @@ public class Module
                 instruction.Count == 0 ||
                 instruction[instruction.Count - 1].OpCode != OpCode.End
                 ;
-        };
+        }
 
         if (this.globals != null)
         {

--- a/WebAssembly/Runtime/Compilation/BlockStack.cs
+++ b/WebAssembly/Runtime/Compilation/BlockStack.cs
@@ -7,7 +7,7 @@ namespace WebAssembly.Runtime.Compilation;
 // Simplified in other ways since, being internal, it doesn't need to validate input or the provide the full Stack feature set.
 internal sealed class BlockStack
 {
-    private BlockTypeInstruction?[] stack = Array.Empty<BlockTypeInstruction?>();
+    private BlockTypeInstruction?[] stack = [ ];
     public int Count { get; private set; }
 
     public void Clear()

--- a/WebAssembly/Runtime/Compilation/Signature.cs
+++ b/WebAssembly/Runtime/Compilation/Signature.cs
@@ -18,8 +18,8 @@ internal sealed class Signature : IEquatable<WebAssemblyType>
     private Signature()
     {
         this.TypeIndex = uint.MaxValue;
-        this.ReturnTypes = this.ParameterTypes = Array.Empty<Type>();
-        this.RawReturnTypes = this.RawParameterTypes = Array.Empty<WebAssemblyValueType>();
+        this.ReturnTypes = this.ParameterTypes = [ ];
+        this.RawReturnTypes = this.RawParameterTypes = [ ];
     }
 
     public Signature(WebAssemblyValueType returnType)

--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -135,7 +135,7 @@ public static class Compile
             }
         }
 
-        return (IDictionary<string, IDictionary<string, RuntimeImport>> imports) =>
+        return imports =>
         {
             try
             {
@@ -143,9 +143,9 @@ public static class Compile
             }
             catch (TargetInvocationException x)
 #if DEBUG
-                when (!System.Diagnostics.Debugger.IsAttached)
+            when (!System.Diagnostics.Debugger.IsAttached)
 #endif
-                {
+            {
                 ExceptionDispatchInfo.Capture(x.InnerException ?? x).Throw();
                 throw;
             }
@@ -304,7 +304,7 @@ public static class Compile
 
                 case Section.Function:
                     {
-                        var importedFunctionCount = internalFunctions == null ? 0 : internalFunctions.Length;
+                        var importedFunctionCount = internalFunctions?.Length ?? 0;
                         var functionIndexSize = checked((int)(importedFunctionCount + reader.ReadVarUInt32()));
                         if (functionSignatures != null)
                         {
@@ -317,7 +317,7 @@ public static class Compile
                         }
                         if (importedFunctionCount != 0)
                         {
-                            Array.Resize(ref internalFunctions, checked(functionSignatures.Length));
+                            Array.Resize(ref internalFunctions, functionSignatures.Length);
                             context.Methods = internalFunctions;
                         }
                         else
@@ -373,7 +373,7 @@ public static class Compile
                                             var parms = constructor.GetParameters();
                                             return parms.Length == 1 && parms[0].ParameterType == typeof(uint);
                                         })
-                                        .Single()); ;
+                                        .Single());
                                     instanceConstructorIL.Emit(OpCodes.Newobj, typeof(FunctionTable)
                                         .GetTypeInfo()
                                         .DeclaredConstructors
@@ -730,7 +730,6 @@ public static class Compile
                             .GetTypeInfo()
                             .GetDeclaredProperty(nameof(MemoryImport.Method))!
                             .GetMethod!);
-                        ;
                         ImportException.EmitTryCast(instanceConstructorIL, typedDelegate);
                         instanceConstructorIL.Emit(OpCodes.Stfld, delFieldBuilder);
 
@@ -1116,7 +1115,7 @@ public static class Compile
             {
                 var preInitializerOffset = reader.Offset;
                 var initializer = Instruction.ParseInitializerExpression(reader).ToArray();
-                if (initializer.Length != 2 || initializer[0] is not Instructions.Int32Constant c || initializer[1] is not Instructions.End)
+                if (initializer is not [ Instructions.Int32Constant c, Instructions.End ])
                     throw new ModuleLoadException("Initializer expression support for the Element section is limited to a single Int32 constant followed by end.", preInitializerOffset);
 
                 offset = (uint)c.Value;

--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -1115,7 +1115,7 @@ public static class Compile
             {
                 var preInitializerOffset = reader.Offset;
                 var initializer = Instruction.ParseInitializerExpression(reader).ToArray();
-                if (initializer is not [ Instructions.Int32Constant c, Instructions.End ])
+                if (initializer.Length != 2 || initializer[0] is not Instructions.Int32Constant c || initializer[1] is not Instructions.End)
                     throw new ModuleLoadException("Initializer expression support for the Element section is limited to a single Int32 constant followed by end.", preInitializerOffset);
 
                 offset = (uint)c.Value;

--- a/WebAssembly/Runtime/FunctionTable.cs
+++ b/WebAssembly/Runtime/FunctionTable.cs
@@ -12,20 +12,18 @@ public class FunctionTable : TableImport
 {
     internal static readonly RegeneratingWeakReference<MethodInfo> IndexGetter = new(() =>
         typeof(FunctionTable)
-        .GetTypeInfo()
-        .DeclaredProperties
-        .Where(prop => prop.GetIndexParameters().Length > 0)
-        .First()
-        .GetMethod!
+           .GetTypeInfo()
+           .DeclaredProperties
+           .First(prop => prop.GetIndexParameters().Length > 0)
+           .GetMethod!
         );
 
     internal static readonly RegeneratingWeakReference<MethodInfo> IndexSetter = new(() =>
         typeof(FunctionTable)
-        .GetTypeInfo()
-        .DeclaredProperties
-        .Where(prop => prop.GetIndexParameters().Length > 0)
-        .First()
-        .SetMethod!
+           .GetTypeInfo()
+           .DeclaredProperties
+           .First(prop => prop.GetIndexParameters().Length > 0)
+           .SetMethod!
         );
 
     internal static readonly RegeneratingWeakReference<MethodInfo> LengthGetter = new(() =>

--- a/WebAssembly/Runtime/ImportDictionary.cs
+++ b/WebAssembly/Runtime/ImportDictionary.cs
@@ -7,7 +7,7 @@ namespace WebAssembly.Runtime;
 /// No members of its own, essentially an alias for a dictionary of dictionaries,
 /// both keyed by strings, with the inner dictionary having values of <see cref="RuntimeImport"/>.
 /// </summary>
-public class ImportDictionary : Dictionary<string, IDictionary<string, RuntimeImport>>, IDictionary<string, IDictionary<string, RuntimeImport>>
+public class ImportDictionary : Dictionary<string, IDictionary<string, RuntimeImport>>
 {
     /// <summary>
     /// Creates a new <see cref="ImportDictionary"/> instance.

--- a/WebAssembly/Runtime/RuntimeImport.cs
+++ b/WebAssembly/Runtime/RuntimeImport.cs
@@ -72,7 +72,7 @@ public abstract class RuntimeImport
                         if (getter == null)
                             continue; // TODO: Throw an exception for missing getter.
 
-                        if (getter.Invoke(exports, Array.Empty<object>()) is not FunctionTable table)
+                        if (getter.Invoke(exports, [ ]) is not FunctionTable table)
                             continue; // TODO: Throw an exception for missing result.
 
                         yield return (native.Name, table);

--- a/WebAssembly/Runtime/UnmanagedMemory.cs
+++ b/WebAssembly/Runtime/UnmanagedMemory.cs
@@ -11,11 +11,11 @@ namespace WebAssembly.Runtime;
 public sealed class UnmanagedMemory : IDisposable
 {
     internal static readonly RegeneratingWeakReference<MethodInfo> SizeGetter = new(()
-        => typeof(UnmanagedMemory).GetTypeInfo().DeclaredProperties.Where(prop => prop.Name == nameof(Size)).First().GetMethod!);
+        => typeof(UnmanagedMemory).GetTypeInfo().DeclaredProperties.First(prop => prop.Name == nameof(Size)).GetMethod!);
     internal static readonly RegeneratingWeakReference<MethodInfo> StartGetter = new(()
-        => typeof(UnmanagedMemory).GetTypeInfo().DeclaredProperties.Where(prop => prop.Name == nameof(Start)).First().GetMethod!);
+        => typeof(UnmanagedMemory).GetTypeInfo().DeclaredProperties.First(prop => prop.Name == nameof(Start)).GetMethod!);
     internal static readonly RegeneratingWeakReference<MethodInfo> GrowMethod = new(()
-        => typeof(UnmanagedMemory).GetTypeInfo().DeclaredMethods.Where(prop => prop.Name == nameof(Grow)).First());
+        => typeof(UnmanagedMemory).GetTypeInfo().DeclaredMethods.First(prop => prop.Name == nameof(Grow)));
 
     private bool disposed;
 

--- a/WebAssembly/Section.cs
+++ b/WebAssembly/Section.cs
@@ -57,5 +57,5 @@ public enum Section : byte
 
 static class SectionExtensions
 {
-    public static bool IsValid(this Section section) => section >= Section.None && section <= Section.Data;
+    public static bool IsValid(this Section section) => section <= Section.Data;
 }


### PR DESCRIPTION
Fixed various minor code quality issues, as suggested by ReSharper. Hopefully all of these are fairly "non controversial" changes:
 - Correctly aligned code in Compile.cs
 - Removed redundant interface in ImportDictionary (also fixing an issue with mismatched nullability annotations)
 - Removed excess semicolon in FunctionBody.cs, Module.cs, Compile.cs
 - Using `x.First(y)` instead of `x.Where(y).First()` in FunctionTable.cs, UnmanagedMemory.cs
 - Using pattern matching in End.cs, Compile.cs
 - Used collection expression `[]` instead of `Array.Empty<T>` in BlockStack.cs, Signature.cs, RuntimeImport.cs
 - Removed redundant check in Section.cs (`Section` cannot be < `Section.None`)
 - Removed unnecessary `using` in Branch.cs, BranchIf.cs
 - Removed redundant `checked` context in Compile.cs
 - Removed redundant `sealed` keywords (on methods, where the whole class is sealed) in CompilationContext.cs, GlobalInfo.cs

There are a large number of nullability issues of the type `﻿Expression is always false according to nullable reference types' annotations` or `﻿Conditional access qualifier expression is never null according to nullable reference types' annotations`. Are you happy for me to fix all of these in a followup PR? I'll inspect each case and either remove the redundant null checks, or add a nullability annotation where appropriate.