### PR TITLE
Removed Some Redundant Code

### DIFF
--- a/WebAssembly/CustomSection.cs
+++ b/WebAssembly/CustomSection.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace WebAssembly;
 
@@ -40,10 +41,13 @@ public class CustomSection
     /// <summary>
     /// The name of the custom section; nulls are converted to <see cref="string.Empty"/>.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [AllowNull]
+#endif
     public string Name
     {
         get => this.name ??= string.Empty;
-        set => this.name = value ?? string.Empty;
+        set => this.name = value;
     }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)] //Wrapped by a property
@@ -52,10 +56,13 @@ public class CustomSection
     /// <summary>
     /// The content of the custom section; nulls are converted to an empty modifiable collection.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [AllowNull]
+#endif
     public IList<byte> Content
     {
-        get => this.content ??= new List<byte>();
-        set => this.content = value ?? new List<byte>();
+        get => this.content ??= [];
+        set => this.content = value ?? [];
     }
 
     internal void WriteTo(Writer writer)

--- a/WebAssembly/FunctionBody.cs
+++ b/WebAssembly/FunctionBody.cs
@@ -90,8 +90,8 @@ public class FunctionBody : IEquatable<FunctionBody>
     /// <returns>The hash code.</returns>
     public override int GetHashCode()
         => HashCode.Combine(
-            this.Locals.Select(local => local?.GetHashCode())
-            .Concat(this.Code.Select(instruction => instruction?.GetHashCode()
+            this.Locals.Select(local => local.GetHashCode())
+            .Concat(this.Code.Select(instruction => instruction.GetHashCode()
             )));
 
     /// <summary>

--- a/WebAssembly/Module.cs
+++ b/WebAssembly/Module.cs
@@ -381,7 +381,6 @@ public class Module
         static bool LastOpCodeIsNotEnd(IList<Instruction> instruction)
         {
             return
-                instruction == null ||
                 instruction.Count == 0 ||
                 instruction[instruction.Count - 1].OpCode != OpCode.End
                 ;
@@ -436,7 +435,6 @@ public class Module
         }
 
         var customSectionsByPrecedingSection = this.customSections?
-            .Where(custom => custom != null)
             .GroupBy(custom => custom.PrecedingSection)
             .ToDictionary(group => group.Key);
 
@@ -453,7 +451,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.types.Count);
                 foreach (var type in this.types)
-                    type?.WriteTo(sectionWriter);
+                    type.WriteTo(sectionWriter);
             });
         }
         WriteCustomSection(buffer, writer, Section.Type, customSectionsByPrecedingSection);
@@ -464,7 +462,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.imports.Count);
                 foreach (var import in this.imports)
-                    import?.WriteTo(sectionWriter);
+                    import.WriteTo(sectionWriter);
             });
         }
         WriteCustomSection(buffer, writer, Section.Import, customSectionsByPrecedingSection);
@@ -475,7 +473,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.functions.Count);
                 foreach (var function in this.functions)
-                    function?.WriteTo(sectionWriter);
+                    function.WriteTo(sectionWriter);
             });
         }
         WriteCustomSection(buffer, writer, Section.Function, customSectionsByPrecedingSection);
@@ -486,7 +484,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.tables.Count);
                 foreach (var table in this.tables)
-                    table?.WriteTo(sectionWriter);
+                    table.WriteTo(sectionWriter);
             });
         }
         WriteCustomSection(buffer, writer, Section.Table, customSectionsByPrecedingSection);
@@ -497,7 +495,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.memories.Count);
                 foreach (var memory in this.memories)
-                    memory?.WriteTo(sectionWriter);
+                    memory.WriteTo(sectionWriter);
             });
         }
         WriteCustomSection(buffer, writer, Section.Memory, customSectionsByPrecedingSection);
@@ -508,7 +506,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.globals.Count);
                 foreach (var global in this.globals)
-                    global?.WriteTo(sectionWriter);
+                    global.WriteTo(sectionWriter);
             });
         }
         WriteCustomSection(buffer, writer, Section.Global, customSectionsByPrecedingSection);
@@ -519,7 +517,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.exports.Count);
                 foreach (var export in this.exports)
-                    export?.WriteTo(sectionWriter);
+                    export.WriteTo(sectionWriter);
             });
         }
         WriteCustomSection(buffer, writer, Section.Export, customSectionsByPrecedingSection);
@@ -539,7 +537,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.elements.Count);
                 foreach (var element in this.elements)
-                    element?.WriteTo(sectionWriter);
+                    element.WriteTo(sectionWriter);
             });
         }
         WriteCustomSection(buffer, writer, Section.Element, customSectionsByPrecedingSection);
@@ -550,7 +548,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.codes.Count);
                 foreach (var code in this.codes)
-                    code?.WriteTo(sectionWriter, buffer);
+                    code.WriteTo(sectionWriter, buffer);
             });
         }
         WriteCustomSection(buffer, writer, Section.Code, customSectionsByPrecedingSection);
@@ -561,7 +559,7 @@ public class Module
             {
                 sectionWriter.WriteVar((uint)this.data.Count);
                 foreach (var data in this.data)
-                    data?.WriteTo(sectionWriter);
+                    data.WriteTo(sectionWriter);
             });
         }
         WriteCustomSection(buffer, writer, Section.Data, customSectionsByPrecedingSection);

--- a/WebAssembly/Runtime/Compilation/CompilationContext.cs
+++ b/WebAssembly/Runtime/Compilation/CompilationContext.cs
@@ -16,9 +16,9 @@ internal sealed class CompilationContext(CompilerConfiguration configuration)
 
     sealed class FunctionOuterBlock(BlockType type) : BlockTypeInstruction(type)
     {
-        public sealed override OpCode OpCode => OpCode.Return; // "Return" is the most accurate fake opcode for the outer block.
+        public override OpCode OpCode => OpCode.Return; // "Return" is the most accurate fake opcode for the outer block.
 
-        internal sealed override void Compile(CompilationContext context) => throw new NotSupportedException();
+        internal override void Compile(CompilationContext context) => throw new NotSupportedException();
     }
 
     public void Reset(

--- a/WebAssembly/Runtime/Compile.cs
+++ b/WebAssembly/Runtime/Compile.cs
@@ -215,7 +215,7 @@ public static class Compile
                 throw new ModuleLoadException("Unsupported version, only version 0x1 is accepted.", 4);
         }
 
-        uint memoryPagesMinimum = 0;
+        uint memoryPagesMinimum;
         uint memoryPagesMaximum = 0;
 
         Signature[]? signatures = null;
@@ -438,7 +438,7 @@ public static class Compile
                             return parms.Length == 2 && parms[0].ParameterType == typeof(uint) && parms[1].ParameterType == typeof(uint?);
                         }).First());
 
-                        instanceConstructorIL.Emit(OpCodes.Stfld, memory!);
+                        instanceConstructorIL.Emit(OpCodes.Stfld, memory);
 
                         exportsBuilder.AddInterfaceImplementation(typeof(IDisposable));
 
@@ -452,7 +452,7 @@ public static class Compile
 
                         var disposeIL = dispose.GetILGenerator();
                         disposeIL.Emit(OpCodes.Ldarg_0);
-                        disposeIL.Emit(OpCodes.Ldfld, memory!);
+                        disposeIL.Emit(OpCodes.Ldfld, memory);
                         disposeIL.Emit(OpCodes.Call, typeof(UnmanagedMemory)
                             .GetTypeInfo()
                             .DeclaredMethods
@@ -560,7 +560,7 @@ public static class Compile
 
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Newobj, exportInfo!.DeclaredConstructors.First());
+            il.Emit(OpCodes.Newobj, exportInfo.DeclaredConstructors.First());
             il.Emit(OpCodes.Call, instanceContainer
                 .GetTypeInfo()
                 .DeclaredConstructors
@@ -571,7 +571,7 @@ public static class Compile
                 );
             il.Emit(OpCodes.Ret);
 
-            instance = instanceBuilder.CreateTypeInfo()!;
+            instance = instanceBuilder.CreateTypeInfo();
         }
 
         module.CreateGlobalFunctions();
@@ -737,7 +737,7 @@ public static class Compile
                         instanceConstructorIL.Emit(OpCodes.Ldarg_0);
                         instanceConstructorIL.Emit(OpCodes.Ldarg_0);
                         instanceConstructorIL.Emit(OpCodes.Call, importedMemoryProvider);
-                        instanceConstructorIL.Emit(OpCodes.Stfld, memory!);
+                        instanceConstructorIL.Emit(OpCodes.Stfld, memory);
                     }
                     break;
                 case ExternalKind.Global:

--- a/WebAssembly/Runtime/GlobalImport.cs
+++ b/WebAssembly/Runtime/GlobalImport.cs
@@ -111,7 +111,7 @@ public class GlobalImport : RuntimeImport
 
         var gret = getter.Method.ReturnType;
 
-        if (gret == null || !gret.TryConvertToValueType(out var gtype))
+        if (!gret.TryConvertToValueType(out var gtype))
             throw new ArgumentException("getter does not return a compatible type.", nameof(getter));
 
         if (setter != null)
@@ -124,7 +124,7 @@ public class GlobalImport : RuntimeImport
                 throw new ArgumentException("setter must have exactly 1 parameter.", nameof(setter));
 
             var sparm = sparms[0].ParameterType;
-            if (sparm == null || !sparm.TryConvertToValueType(out var stype))
+            if (!sparm.TryConvertToValueType(out var stype))
                 throw new ArgumentException("setter does not accept a compatible type.", nameof(setter));
 
             if (stype != gtype)

--- a/WebAssembly/Runtime/Helpers.cs
+++ b/WebAssembly/Runtime/Helpers.cs
@@ -28,7 +28,7 @@ public static class Helpers
         ArgumentNullException.ThrowIfNull(field, nameof(field));
 #endif
 
-        if (!imports.TryGetValue(module, out var fields) || !fields.TryGetValue(field, out var import) || import == null)
+        if (!imports.TryGetValue(module, out var fields) || !fields.TryGetValue(field, out var import))
         {
             throw new ImportException($"Missing import for {module}::{field}.");
         }


### PR DESCRIPTION
Removed some minor redundant code, as highlighted by R#
 - Mostly null handling code that's unnecessary because the type statically cannot be null
 - Null suppression of values already known to be not null
 - Sealed overrides when the class is sealed

`Name` and `Content` properties of `CustomSection` are documented as allowing null to be assigned. I haven't changed that behaviour, since it's specifically documented I assume it's important! Adding `AllowNull` lets null be assigned, but does _not_ allow null to be returned.