### PR TITLE
DataCount Section Support

### DIFF
--- a/WebAssembly/Module.cs
+++ b/WebAssembly/Module.cs
@@ -348,6 +348,12 @@ public class Module
                         }
                         break;
 
+                    case Section.DataCount: //Optional section, indicates the expected length of the data segment vector
+                        {
+                            reader.ReadUInt32();
+                        }
+                        break;
+
                     default:
                         throw new ModuleLoadException($"Unrecognized section type {id}.", preSectionOffset);
                 }

--- a/WebAssembly/Section.cs
+++ b/WebAssembly/Section.cs
@@ -1,4 +1,6 @@
-﻿namespace WebAssembly;
+﻿using System;
+
+namespace WebAssembly;
 
 /// <summary>
 /// The standard section identifiers.
@@ -52,10 +54,14 @@ public enum Section : byte
     /// <summary>
     /// Data segments.
     /// </summary>
-    Data
+    Data,
+    /// <summary>
+    /// Optional segment which indicates the number of sata segments
+    /// </summary>
+    DataCount,
 }
 
 static class SectionExtensions
 {
-    public static bool IsValid(this Section section) => section <= Section.Data;
+    public static bool IsValid(this Section section) => section <= Section.DataCount;
 }


### PR DESCRIPTION
Added support for `DataCount` section in module loading. This is an optional section, only used to simplify single pass verification of a module. spec: https://webassembly.github.io/spec/core/binary/modules.html#data-count-section

No additional verification is performed, the correct value is simply read and discarded. This allows files with this section to be loaded.